### PR TITLE
Support module

### DIFF
--- a/rust/src/analyzer/definitions.rs
+++ b/rust/src/analyzer/definitions.rs
@@ -1,9 +1,10 @@
-//! Definition Handlers - Processing Ruby class/method definitions
+//! Definition Handlers - Processing Ruby class/method/module definitions
 //!
 //! This module is responsible for:
 //! - Class definition scope management (class Foo ... end)
-//! - Method definition scope management (def bar ... end)
-//! - Extracting class names from AST nodes
+//! - Module definition scope management (module Bar ... end)
+//! - Method definition scope management (def baz ... end)
+//! - Extracting class/module names from AST nodes
 
 use crate::env::GlobalEnv;
 
@@ -12,12 +13,17 @@ pub fn install_class(genv: &mut GlobalEnv, class_name: String) {
     genv.enter_class(class_name);
 }
 
+/// Install module definition
+pub fn install_module(genv: &mut GlobalEnv, module_name: String) {
+    genv.enter_module(module_name);
+}
+
 /// Install method definition
 pub fn install_method(genv: &mut GlobalEnv, method_name: String) {
     genv.enter_method(method_name);
 }
 
-/// Exit current scope (class or method)
+/// Exit current scope (class, module, or method)
 pub fn exit_scope(genv: &mut GlobalEnv) {
     genv.exit_scope();
 }
@@ -28,6 +34,15 @@ pub fn extract_class_name(class_node: &ruby_prism::ClassNode) -> String {
         String::from_utf8_lossy(constant_read.name().as_slice()).to_string()
     } else {
         "UnknownClass".to_string()
+    }
+}
+
+/// Extract module name from ModuleNode
+pub fn extract_module_name(module_node: &ruby_prism::ModuleNode) -> String {
+    if let Some(constant_read) = module_node.constant_path().as_constant_read_node() {
+        String::from_utf8_lossy(constant_read.name().as_slice()).to_string()
+    } else {
+        "UnknownModule".to_string()
     }
 }
 
@@ -50,6 +65,20 @@ mod tests {
     }
 
     #[test]
+    fn test_enter_exit_module_scope() {
+        let mut genv = GlobalEnv::new();
+
+        install_module(&mut genv, "Utils".to_string());
+        assert_eq!(
+            genv.scope_manager.current_module_name(),
+            Some("Utils".to_string())
+        );
+
+        exit_scope(&mut genv);
+        assert_eq!(genv.scope_manager.current_module_name(), None);
+    }
+
+    #[test]
     fn test_nested_method_scope() {
         let mut genv = GlobalEnv::new();
 
@@ -66,5 +95,24 @@ mod tests {
         exit_scope(&mut genv); // exit class
 
         assert_eq!(genv.scope_manager.current_class_name(), None);
+    }
+
+    #[test]
+    fn test_method_in_module() {
+        let mut genv = GlobalEnv::new();
+
+        install_module(&mut genv, "Helpers".to_string());
+        install_method(&mut genv, "format".to_string());
+
+        // Should find module context from within method
+        assert_eq!(
+            genv.scope_manager.current_module_name(),
+            Some("Helpers".to_string())
+        );
+
+        exit_scope(&mut genv); // exit method
+        exit_scope(&mut genv); // exit module
+
+        assert_eq!(genv.scope_manager.current_module_name(), None);
     }
 }

--- a/rust/src/env/global_env.rs
+++ b/rust/src/env/global_env.rs
@@ -187,12 +187,23 @@ impl GlobalEnv {
         scope_id
     }
 
+    /// Enter a module scope
+    pub fn enter_module(&mut self, name: String) -> ScopeId {
+        let scope_id = self.scope_manager.new_scope(ScopeKind::Module { name });
+        self.scope_manager.enter_scope(scope_id);
+        scope_id
+    }
+
     /// Enter a method scope
     pub fn enter_method(&mut self, name: String) -> ScopeId {
-        let class_name = self.scope_manager.current_class_name();
+        // Look for class or module context
+        let receiver_type = self
+            .scope_manager
+            .current_class_name()
+            .or_else(|| self.scope_manager.current_module_name());
         let scope_id = self.scope_manager.new_scope(ScopeKind::Method {
             name,
-            receiver_type: class_name,
+            receiver_type,
         });
         self.scope_manager.enter_scope(scope_id);
         scope_id


### PR DESCRIPTION
Add basic module scope support

Enable parsing and scope management for Ruby module definitions.
This allows the type checker to properly handle methods defined
within modules and track their context.

# Changes
- Add ModuleNode AST processing in install.rs
- Add extract_module_name() and install_module() in definitions.rs
- Add enter_module() method in global_env.rs
- Add current_module_name() in scope.rs
- Add lookup_instance_var_in_module() in scope.rs
- Add set_instance_var_in_module() in scope.rs
- Update enter_method() to resolve receiver_type from module context
- Add unit tests for module scope management
