### PR TITLE
Release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2025-02-08
+
+### Added
+
+- Method parameter type inference support ([#3](https://github.com/dak2/method-ray/pull/3))
+- Block parameter type variable resolution ([#4](https://github.com/dak2/method-ray/pull/4))
+- Module scope support ([#6](https://github.com/dak2/method-ray/pull/6))
+- Fully qualified name support for nested classes/modules ([#7](https://github.com/dak2/method-ray/pull/7))
+- Float type support ([#8](https://github.com/dak2/method-ray/pull/8))
+- Regexp type support ([#9](https://github.com/dak2/method-ray/pull/9))
+- Range type support ([#10](https://github.com/dak2/method-ray/pull/10))
+- Generic type inference for Range, Hash, and nested Array ([#11](https://github.com/dak2/method-ray/pull/11))
+
+### Fixed
+
+- Call operator location ([#12](https://github.com/dak2/method-ray/pull/12))
+- Memory leak ([#13](https://github.com/dak2/method-ray/pull/13))
+
+### Changed
+
+- Extract BinaryLocator class from Commands module ([#5](https://github.com/dak2/method-ray/pull/5))
+- Migrate Rust integration tests to Ruby CLI and Rust unit tests ([#14](https://github.com/dak2/method-ray/pull/14))
+- Remove unnecessary test files and logs ([#1](https://github.com/dak2/method-ray/pull/1), [#15](https://github.com/dak2/method-ray/pull/15))
+
 ## [0.1.2] - 2025-01-19
 
 ### Added
@@ -30,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 - `methodray check` - Static type checking for Ruby files
 
+[0.1.3]: https://github.com/dak2/method-ray/releases/tag/v0.1.3
 [0.1.2]: https://github.com/dak2/method-ray/releases/tag/v0.1.2
 [0.1.1]: https://github.com/dak2/method-ray/releases/tag/v0.1.1
 [0.1.0]: https://github.com/dak2/method-ray/releases/tag/v0.1.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    method-ray (0.1.2)
+    method-ray (0.1.3)
       rbs (~> 3.0)
 
 GEM
@@ -66,7 +66,7 @@ CHECKSUMS
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  method-ray (0.1.2)
+  method-ray (0.1.3)
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.1) sha256=06f6a725d2cd91e5e7f2b7c32ba143631e1f7c8ae2fb918fc4cebec187e6a688

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methodray"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 
 [lib]

--- a/lib/methodray/version.rb
+++ b/lib/methodray/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MethodRay
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methodray-core"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION

### Added

- Method parameter type inference support ([#3](https://github.com/dak2/method-ray/pull/3))
- Block parameter type variable resolution ([#4](https://github.com/dak2/method-ray/pull/4))
- Module scope support ([#6](https://github.com/dak2/method-ray/pull/6))
- Fully qualified name support for nested classes/modules ([#7](https://github.com/dak2/method-ray/pull/7))
- Float type support ([#8](https://github.com/dak2/method-ray/pull/8))
- Regexp type support ([#9](https://github.com/dak2/method-ray/pull/9))
- Range type support ([#10](https://github.com/dak2/method-ray/pull/10))
- Generic type inference for Range, Hash, and nested Array ([#11](https://github.com/dak2/method-ray/pull/11))

### Fixed

- Call operator location ([#12](https://github.com/dak2/method-ray/pull/12))
- Memory leak ([#13](https://github.com/dak2/method-ray/pull/13))

### Changed

- Extract BinaryLocator class from Commands module ([#5](https://github.com/dak2/method-ray/pull/5))
- Migrate Rust integration tests to Ruby CLI and Rust unit tests ([#14](https://github.com/dak2/method-ray/pull/14))
- Remove unnecessary test files and logs ([#1](https://github.com/dak2/method-ray/pull/1), [#15](https://github.com/dak2/method-ray/pull/15))