### PR TITLE
Add parameter type propagation from call-site arguments

### DIFF
--- a/rust/src/analyzer/calls.rs
+++ b/rust/src/analyzer/calls.rs
@@ -14,14 +14,15 @@ pub fn install_method_call(
     genv: &mut GlobalEnv,
     recv_vtx: VertexId,
     method_name: String,
+    arg_vtxs: Vec<VertexId>,
     location: Option<SourceLocation>,
 ) -> VertexId {
     // Create Vertex for return value
     let ret_vtx = genv.new_vertex();
 
-    // Create MethodCallBox with location
+    // Create MethodCallBox with location and argument vertices
     let box_id = genv.alloc_box_id();
-    let call_box = MethodCallBox::new(box_id, recv_vtx, method_name, ret_vtx, location);
+    let call_box = MethodCallBox::new(box_id, recv_vtx, method_name, ret_vtx, arg_vtxs, location);
     genv.register_box(box_id, Box::new(call_box));
 
     ret_vtx
@@ -37,7 +38,8 @@ mod tests {
         let mut genv = GlobalEnv::new();
 
         let recv_vtx = genv.new_source(Type::string());
-        let ret_vtx = install_method_call(&mut genv, recv_vtx, "upcase".to_string(), None);
+        let ret_vtx =
+            install_method_call(&mut genv, recv_vtx, "upcase".to_string(), vec![], None);
 
         // Return vertex should exist
         assert!(genv.get_vertex(ret_vtx).is_some());
@@ -48,7 +50,8 @@ mod tests {
         let mut genv = GlobalEnv::new();
 
         let recv_vtx = genv.new_source(Type::string());
-        let _ret_vtx = install_method_call(&mut genv, recv_vtx, "upcase".to_string(), None);
+        let _ret_vtx =
+            install_method_call(&mut genv, recv_vtx, "upcase".to_string(), vec![], None);
 
         // Box should be added
         assert_eq!(genv.box_count(), 1);

--- a/rust/src/analyzer/definitions.rs
+++ b/rust/src/analyzer/definitions.rs
@@ -68,9 +68,11 @@ pub(crate) fn process_def_node(
     install_method(genv, method_name.clone());
 
     // Process parameters BEFORE processing body
-    if let Some(params_node) = def_node.parameters() {
-        install_parameters(genv, lenv, changes, source, &params_node);
-    }
+    let param_vtxs = if let Some(params_node) = def_node.parameters() {
+        install_parameters(genv, lenv, changes, source, &params_node)
+    } else {
+        vec![]
+    };
 
     let mut last_vtx = None;
     if let Some(body) = def_node.body() {
@@ -79,7 +81,7 @@ pub(crate) fn process_def_node(
         }
     }
 
-    // Register user-defined method with return vertex (before exiting scope)
+    // Register user-defined method with return vertex and param vertices (before exiting scope)
     if let Some(return_vtx) = last_vtx {
         let recv_type_name = genv
             .scope_manager
@@ -87,7 +89,12 @@ pub(crate) fn process_def_node(
             .or_else(|| genv.scope_manager.current_module_name());
 
         if let Some(name) = recv_type_name {
-            genv.register_user_method(Type::instance(&name), &method_name, return_vtx);
+            genv.register_user_method(
+                Type::instance(&name),
+                &method_name,
+                return_vtx,
+                param_vtxs,
+            );
         }
     }
 

--- a/rust/src/analyzer/dispatch.rs
+++ b/rust/src/analyzer/dispatch.rs
@@ -35,6 +35,8 @@ pub enum NeedsChildKind<'a> {
         location: SourceLocation,
         /// Optional block attached to the method call
         block: Option<Node<'a>>,
+        /// Arguments to the method call
+        arguments: Vec<Node<'a>>,
     },
 }
 
@@ -103,11 +105,18 @@ pub fn dispatch_needs_child<'a>(node: &Node<'a>, source: &str) -> Option<NeedsCh
             // Get block if present (e.g., `x.each { |i| ... }`)
             let block = call_node.block();
 
+            // Get arguments if present (e.g., `x.foo(1, 2)`)
+            let arguments: Vec<Node<'a>> = call_node
+                .arguments()
+                .map(|args| args.arguments().iter().collect())
+                .unwrap_or_default();
+
             return Some(NeedsChildKind::MethodCall {
                 receiver,
                 method_name,
                 location,
                 block,
+                arguments,
             });
         }
     }
@@ -141,8 +150,17 @@ pub(crate) fn process_needs_child(
             method_name,
             location,
             block,
+            arguments,
         } => {
             let recv_vtx = super::install::install_node(genv, lenv, changes, source, &receiver)?;
+
+            // Process arguments if present
+            let arg_vtxs: Vec<VertexId> = arguments
+                .iter()
+                .filter_map(|arg| {
+                    super::install::install_node(genv, lenv, changes, source, arg)
+                })
+                .collect();
 
             // Handle block if present (e.g., `x.each { |i| ... }`)
             if let Some(block_node) = block {
@@ -164,7 +182,9 @@ pub(crate) fn process_needs_child(
                 }
             }
 
-            Some(finish_method_call(genv, recv_vtx, method_name, location))
+            Some(finish_method_call(
+                genv, recv_vtx, method_name, arg_vtxs, location,
+            ))
         }
     }
 }
@@ -190,7 +210,8 @@ fn finish_method_call(
     genv: &mut GlobalEnv,
     recv_vtx: VertexId,
     method_name: String,
+    arg_vtxs: Vec<VertexId>,
     location: SourceLocation,
 ) -> VertexId {
-    install_method_call(genv, recv_vtx, method_name, Some(location))
+    install_method_call(genv, recv_vtx, method_name, arg_vtxs, Some(location))
 }

--- a/rust/src/analyzer/parameters.rs
+++ b/rust/src/analyzer/parameters.rs
@@ -114,18 +114,24 @@ pub fn install_keyword_rest_parameter(
 }
 
 /// Install method parameters as local variables
+///
+/// Returns a Vec of VertexId for required and optional parameters (positional),
+/// which can be used for argument-to-parameter type propagation.
 pub(crate) fn install_parameters(
     genv: &mut GlobalEnv,
     lenv: &mut LocalEnv,
     changes: &mut ChangeSet,
     source: &str,
     params_node: &ruby_prism::ParametersNode,
-) {
+) -> Vec<VertexId> {
+    let mut param_vtxs = Vec::new();
+
     // Required parameters: def foo(a, b)
     for node in params_node.requireds().iter() {
         if let Some(req_param) = node.as_required_parameter_node() {
             let name = String::from_utf8_lossy(req_param.name().as_slice()).to_string();
-            install_required_parameter(genv, lenv, name);
+            let vtx = install_required_parameter(genv, lenv, name);
+            param_vtxs.push(vtx);
         }
     }
 
@@ -135,17 +141,19 @@ pub(crate) fn install_parameters(
             let name = String::from_utf8_lossy(opt_param.name().as_slice()).to_string();
             let default_value = opt_param.value();
 
-            if let Some(default_vtx) =
+            let vtx = if let Some(default_vtx) =
                 super::install::install_node(genv, lenv, changes, source, &default_value)
             {
-                install_optional_parameter(genv, lenv, changes, name, default_vtx);
+                install_optional_parameter(genv, lenv, changes, name, default_vtx)
             } else {
-                install_required_parameter(genv, lenv, name);
-            }
+                install_required_parameter(genv, lenv, name)
+            };
+            param_vtxs.push(vtx);
         }
     }
 
     // Rest parameter: def foo(*args)
+    // Not included in param_vtxs (variadic args need special handling)
     if let Some(rest_node) = params_node.rest() {
         if let Some(rest_param) = rest_node.as_rest_parameter_node() {
             if let Some(name_id) = rest_param.name() {
@@ -156,6 +164,7 @@ pub(crate) fn install_parameters(
     }
 
     // Keyword rest parameter: def foo(**kwargs)
+    // Not included in param_vtxs (keyword args need special handling)
     if let Some(kwrest_node) = params_node.keyword_rest() {
         if let Some(kwrest_param) = kwrest_node.as_keyword_rest_parameter_node() {
             if let Some(name_id) = kwrest_param.name() {
@@ -164,6 +173,8 @@ pub(crate) fn install_parameters(
             }
         }
     }
+
+    param_vtxs
 }
 
 #[cfg(test)]

--- a/rust/src/env/global_env.rs
+++ b/rust/src/env/global_env.rs
@@ -168,9 +168,10 @@ impl GlobalEnv {
         recv_ty: Type,
         method_name: &str,
         return_vertex: VertexId,
+        param_vertices: Vec<VertexId>,
     ) {
         self.method_registry
-            .register_user_method(recv_ty, method_name, return_vertex);
+            .register_user_method(recv_ty, method_name, return_vertex, param_vertices);
     }
 
     // ===== Type Errors =====

--- a/rust/src/env/method_registry.rs
+++ b/rust/src/env/method_registry.rs
@@ -10,6 +10,7 @@ pub struct MethodInfo {
     pub return_type: Type,
     pub block_param_types: Option<Vec<Type>>,
     pub return_vertex: Option<VertexId>,
+    pub param_vertices: Option<Vec<VertexId>>,
 }
 
 /// Registry for method definitions
@@ -45,6 +46,7 @@ impl MethodRegistry {
                 return_type: ret_ty,
                 block_param_types,
                 return_vertex: None,
+                param_vertices: None,
             },
         );
     }
@@ -55,6 +57,7 @@ impl MethodRegistry {
         recv_ty: Type,
         method_name: &str,
         return_vertex: VertexId,
+        param_vertices: Vec<VertexId>,
     ) {
         self.methods.insert(
             (recv_ty, method_name.to_string()),
@@ -62,6 +65,7 @@ impl MethodRegistry {
                 return_type: Type::Bot,
                 block_param_types: None,
                 return_vertex: Some(return_vertex),
+                param_vertices: Some(param_vertices),
             },
         );
     }
@@ -112,10 +116,30 @@ mod tests {
     fn test_register_user_method_and_resolve() {
         let mut registry = MethodRegistry::new();
         let return_vtx = VertexId(42);
-        registry.register_user_method(Type::instance("User"), "name", return_vtx);
+        registry.register_user_method(Type::instance("User"), "name", return_vtx, vec![]);
 
         let info = registry.resolve(&Type::instance("User"), "name").unwrap();
         assert_eq!(info.return_vertex, Some(VertexId(42)));
         assert_eq!(info.return_type, Type::Bot);
+    }
+
+    #[test]
+    fn test_register_user_method_with_param_vertices() {
+        let mut registry = MethodRegistry::new();
+        let return_vtx = VertexId(10);
+        let param_vtxs = vec![VertexId(20), VertexId(21)];
+        registry.register_user_method(
+            Type::instance("Calc"),
+            "add",
+            return_vtx,
+            param_vtxs,
+        );
+
+        let info = registry.resolve(&Type::instance("Calc"), "add").unwrap();
+        assert_eq!(info.return_vertex, Some(VertexId(10)));
+        let pvs = info.param_vertices.as_ref().unwrap();
+        assert_eq!(pvs.len(), 2);
+        assert_eq!(pvs[0], VertexId(20));
+        assert_eq!(pvs[1], VertexId(21));
     }
 }

--- a/rust/src/graph/box.rs
+++ b/rust/src/graph/box.rs
@@ -23,6 +23,7 @@ pub struct MethodCallBox {
     recv: VertexId,
     method_name: String,
     ret: VertexId,
+    arg_vtxs: Vec<VertexId>,
     location: Option<SourceLocation>, // Source code location
     /// Number of times this box has been rescheduled
     reschedule_count: u8,
@@ -37,6 +38,7 @@ impl MethodCallBox {
         recv: VertexId,
         method_name: String,
         ret: VertexId,
+        arg_vtxs: Vec<VertexId>,
         location: Option<SourceLocation>,
     ) -> Self {
         Self {
@@ -44,6 +46,7 @@ impl MethodCallBox {
             recv,
             method_name,
             ret,
+            arg_vtxs,
             location,
             reschedule_count: 0,
         }
@@ -89,6 +92,15 @@ impl BoxTrait for MethodCallBox {
                 if let Some(return_vtx) = method_info.return_vertex {
                     // User-defined: edge from body's last expr → call site return
                     changes.add_edge(return_vtx, self.ret);
+
+                    // Propagate argument types to parameter vertices
+                    if let Some(param_vtxs) = &method_info.param_vertices {
+                        for (i, param_vtx) in param_vtxs.iter().enumerate() {
+                            if let Some(arg_vtx) = self.arg_vtxs.get(i) {
+                                changes.add_edge(*arg_vtx, *param_vtx);
+                            }
+                        }
+                    }
                 } else {
                     // RBS/builtin: create Source with fixed return type
                     let ret_src_id = genv.new_source(method_info.return_type.clone());
@@ -274,6 +286,7 @@ mod tests {
             x_vtx,
             "upcase".to_string(),
             ret_vtx,
+            vec![],
             None, // No location in test
         );
 
@@ -305,6 +318,7 @@ mod tests {
             x_vtx,
             "unknown_method".to_string(),
             ret_vtx,
+            vec![],
             None, // No location in test
         );
 
@@ -500,7 +514,7 @@ mod tests {
         let body_src = genv.new_source(Type::string());
 
         // Register user-defined method User#name with return_vertex
-        genv.register_user_method(Type::instance("User"), "name", body_src);
+        genv.register_user_method(Type::instance("User"), "name", body_src, vec![]);
 
         // Simulate: user.name (receiver has type User)
         let recv_vtx = genv.new_vertex();
@@ -514,6 +528,7 @@ mod tests {
             recv_vtx,
             "name".to_string(),
             ret_vtx,
+            vec![],
             None,
         );
         genv.register_box(box_id, Box::new(call_box));
@@ -522,5 +537,66 @@ mod tests {
 
         // Return type should be String (propagated from body's last expression)
         assert_eq!(genv.get_vertex(ret_vtx).unwrap().show(), "String");
+    }
+
+    #[test]
+    fn test_method_call_box_param_type_propagation() {
+        let mut genv = GlobalEnv::new();
+
+        // Simulate: def format(value); value.to_s; end
+        // 1. Create parameter vertex for 'value'
+        let param_vtx = genv.new_vertex();
+
+        // 2. Register Integer#to_s -> String (builtin)
+        genv.register_builtin_method(Type::integer(), "to_s", Type::string());
+
+        // 3. Create MethodCallBox for value.to_s (inside method body)
+        let inner_ret_vtx = genv.new_vertex();
+        let inner_box_id = genv.alloc_box_id();
+        let inner_call = MethodCallBox::new(
+            inner_box_id,
+            param_vtx,
+            "to_s".to_string(),
+            inner_ret_vtx,
+            vec![],
+            None,
+        );
+        genv.register_box(inner_box_id, Box::new(inner_call));
+
+        // 4. Register user-defined method Formatter#format with return_vertex and param_vertices
+        genv.register_user_method(
+            Type::instance("Formatter"),
+            "format",
+            inner_ret_vtx,
+            vec![param_vtx],
+        );
+
+        // 5. Simulate call: Formatter.new.format(42)
+        let recv_vtx = genv.new_vertex();
+        let recv_src = genv.new_source(Type::instance("Formatter"));
+        genv.add_edge(recv_src, recv_vtx);
+
+        let arg_vtx = genv.new_source(Type::integer()); // argument: 42
+
+        let call_ret_vtx = genv.new_vertex();
+        let call_box_id = genv.alloc_box_id();
+        let call_box = MethodCallBox::new(
+            call_box_id,
+            recv_vtx,
+            "format".to_string(),
+            call_ret_vtx,
+            vec![arg_vtx],
+            None,
+        );
+        genv.register_box(call_box_id, Box::new(call_box));
+
+        // Run all boxes
+        genv.run_all();
+
+        // param_vtx should have Integer type (propagated from argument)
+        assert_eq!(genv.get_vertex(param_vtx).unwrap().show(), "Integer");
+
+        // Return type should be String (Integer#to_s -> String)
+        assert_eq!(genv.get_vertex(call_ret_vtx).unwrap().show(), "String");
     }
 }

--- a/test/parameter_test.rb
+++ b/test/parameter_test.rb
@@ -108,6 +108,75 @@ class ParameterTest < Minitest::Test
   end
 
   # ============================================
+  # Parameter Type Propagation from Call Site
+  # ============================================
+
+  def test_param_type_propagation_string
+    source = <<~RUBY
+      class Greeter
+        def greet(name)
+          name.upcase
+        end
+
+        def run
+          self.greet("Alice")
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_param_type_propagation_integer
+    source = <<~RUBY
+      class Calculator
+        def double(n)
+          n.even?
+        end
+
+        def run
+          self.double(42)
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_param_type_propagation_multiple_params
+    source = <<~RUBY
+      class Formatter
+        def format(greeting, name)
+          greeting.upcase
+          name.downcase
+        end
+
+        def run
+          self.format("Hello", "World")
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_param_type_propagation_chain
+    source = <<~RUBY
+      class Validator
+        def valid?(str)
+          str.length
+        end
+
+        def check
+          self.valid?("test")
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  # ============================================
   # Error Detection
   # ============================================
 
@@ -115,6 +184,22 @@ class ParameterTest < Minitest::Test
     source = <<~RUBY
       def greet(count = 42)
         count.upcase
+      end
+    RUBY
+
+    assert_check_error(source, method_name: 'upcase', receiver_type: 'Integer')
+  end
+
+  def test_param_type_propagation_error
+    source = <<~RUBY
+      class Processor
+        def process(value)
+          value.upcase
+        end
+
+        def run
+          self.process(42)
+        end
       end
     RUBY
 


### PR DESCRIPTION
When a user-defined method is called (e.g., `self.greet("Alice")`), propagate argument types to parameter vertices via graph edges so that the method body can resolve dependent method calls like `name.upcase`.