### PR TITLE
Add receiverless method call support

### DIFF
--- a/rust/src/analyzer/dispatch.rs
+++ b/rust/src/analyzer/dispatch.rs
@@ -6,6 +6,7 @@
 use crate::env::{GlobalEnv, LocalEnv};
 use crate::graph::{BlockParameterTypeBox, ChangeSet, VertexId};
 use crate::source_map::SourceLocation;
+use crate::types::Type;
 use ruby_prism::Node;
 
 use super::calls::install_method_call;
@@ -36,6 +37,13 @@ pub enum NeedsChildKind<'a> {
         /// Optional block attached to the method call
         block: Option<Node<'a>>,
         /// Arguments to the method call
+        arguments: Vec<Node<'a>>,
+    },
+    /// Implicit self method call: method call without explicit receiver (implicit self)
+    ImplicitSelfCall {
+        method_name: String,
+        location: SourceLocation,
+        block: Option<Node<'a>>,
         arguments: Vec<Node<'a>>,
     },
 }
@@ -91,28 +99,46 @@ pub fn dispatch_needs_child<'a>(node: &Node<'a>, source: &str) -> Option<NeedsCh
         });
     }
 
-    // Method call: x.upcase or x.each { |i| ... }
+    // Method call: x.upcase, x.each { |i| ... }, or name (implicit self)
     if let Some(call_node) = node.as_call_node() {
+        let method_name = String::from_utf8_lossy(call_node.name().as_slice()).to_string();
+        let block = call_node.block();
+        let arguments: Vec<Node<'a>> = call_node
+            .arguments()
+            .map(|args| args.arguments().iter().collect())
+            .unwrap_or_default();
+
         if let Some(receiver) = call_node.receiver() {
-            let method_name = String::from_utf8_lossy(call_node.name().as_slice()).to_string();
-            // Use call_operator_loc (.) for error position, fallback to node location
+            // Explicit receiver: x.upcase, x.each { |i| ... }
             let prism_location = call_node
                 .call_operator_loc()
                 .unwrap_or_else(|| node.location());
             let location =
                 SourceLocation::from_prism_location_with_source(&prism_location, source);
 
-            // Get block if present (e.g., `x.each { |i| ... }`)
-            let block = call_node.block();
-
-            // Get arguments if present (e.g., `x.foo(1, 2)`)
-            let arguments: Vec<Node<'a>> = call_node
-                .arguments()
-                .map(|args| args.arguments().iter().collect())
-                .unwrap_or_default();
-
             return Some(NeedsChildKind::MethodCall {
                 receiver,
+                method_name,
+                location,
+                block,
+                arguments,
+            });
+        } else {
+            // No receiver: implicit self method call (e.g., `name`, `puts "hello"`)
+
+            // TODO: attr_* methods will be handled in next phase (skip for now)
+            const ATTR_METHODS: &[&str] = &["attr_reader", "attr_writer", "attr_accessor"];
+            if ATTR_METHODS.contains(&method_name.as_str()) {
+                return None;
+            }
+
+            let prism_location = call_node
+                .message_loc()
+                .unwrap_or_else(|| node.location());
+            let location =
+                SourceLocation::from_prism_location_with_source(&prism_location, source);
+
+            return Some(NeedsChildKind::ImplicitSelfCall {
                 method_name,
                 location,
                 block,
@@ -153,38 +179,29 @@ pub(crate) fn process_needs_child(
             arguments,
         } => {
             let recv_vtx = super::install::install_node(genv, lenv, changes, source, &receiver)?;
-
-            // Process arguments if present
-            let arg_vtxs: Vec<VertexId> = arguments
-                .iter()
-                .filter_map(|arg| {
-                    super::install::install_node(genv, lenv, changes, source, arg)
-                })
-                .collect();
-
-            // Handle block if present (e.g., `x.each { |i| ... }`)
-            if let Some(block_node) = block {
-                if let Some(block) = block_node.as_block_node() {
-                    let param_vtxs = super::blocks::process_block_node_with_params(
-                        genv, lenv, changes, source, &block,
-                    );
-
-                    if !param_vtxs.is_empty() {
-                        let box_id = genv.alloc_box_id();
-                        let block_box = BlockParameterTypeBox::new(
-                            box_id,
-                            recv_vtx,
-                            method_name.clone(),
-                            param_vtxs,
-                        );
-                        genv.register_box(box_id, Box::new(block_box));
-                    }
-                }
-            }
-
-            Some(finish_method_call(
-                genv, recv_vtx, method_name, arg_vtxs, location,
-            ))
+            process_method_call_common(
+                genv, lenv, changes, source, recv_vtx, method_name, location, block, arguments,
+            )
+        }
+        NeedsChildKind::ImplicitSelfCall {
+            method_name,
+            location,
+            block,
+            arguments,
+        } => {
+            // Use the same naming as method registration in definitions.rs
+            let recv_type_name = genv
+                .scope_manager
+                .current_class_name()
+                .or_else(|| genv.scope_manager.current_module_name());
+            let recv_vtx = if let Some(name) = recv_type_name {
+                genv.new_source(Type::instance(&name))
+            } else {
+                genv.new_source(Type::instance("Object"))
+            };
+            process_method_call_common(
+                genv, lenv, changes, source, recv_vtx, method_name, location, block, arguments,
+            )
         }
     }
 }
@@ -205,6 +222,48 @@ fn finish_local_var_write(
     install_local_var_write(genv, lenv, changes, var_name, value_vtx)
 }
 
+/// MethodCall / ImplicitSelfCall common processing:
+/// Handles argument processing, block processing, and MethodCallBox creation after recv_vtx is obtained
+fn process_method_call_common<'a>(
+    genv: &mut GlobalEnv,
+    lenv: &mut LocalEnv,
+    changes: &mut ChangeSet,
+    source: &str,
+    recv_vtx: VertexId,
+    method_name: String,
+    location: SourceLocation,
+    block: Option<Node<'a>>,
+    arguments: Vec<Node<'a>>,
+) -> Option<VertexId> {
+    let arg_vtxs: Vec<VertexId> = arguments
+        .iter()
+        .filter_map(|arg| super::install::install_node(genv, lenv, changes, source, arg))
+        .collect();
+
+    if let Some(block_node) = block {
+        if let Some(block) = block_node.as_block_node() {
+            let param_vtxs = super::blocks::process_block_node_with_params(
+                genv, lenv, changes, source, &block,
+            );
+
+            if !param_vtxs.is_empty() {
+                let box_id = genv.alloc_box_id();
+                let block_box = BlockParameterTypeBox::new(
+                    box_id,
+                    recv_vtx,
+                    method_name.clone(),
+                    param_vtxs,
+                );
+                genv.register_box(box_id, Box::new(block_box));
+            }
+        }
+    }
+
+    Some(finish_method_call(
+        genv, recv_vtx, method_name, arg_vtxs, location,
+    ))
+}
+
 /// Finish method call after receiver is processed
 fn finish_method_call(
     genv: &mut GlobalEnv,
@@ -214,4 +273,249 @@ fn finish_method_call(
     location: SourceLocation,
 ) -> VertexId {
     install_method_call(genv, recv_vtx, method_name, arg_vtxs, Some(location))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analyzer::install::AstInstaller;
+    use crate::parser::ParseSession;
+
+    /// Helper: parse Ruby source, process with AstInstaller, and return GlobalEnv
+    fn analyze(source: &str) -> GlobalEnv {
+        let session = ParseSession::new();
+        let parse_result = session.parse_source(source, "test.rb").unwrap();
+        let root = parse_result.node();
+        let program = root.as_program_node().unwrap();
+
+        let mut genv = GlobalEnv::new();
+        let mut lenv = LocalEnv::new();
+
+        let mut installer = AstInstaller::new(&mut genv, &mut lenv, source);
+        for stmt in &program.statements().body() {
+            installer.install_node(&stmt);
+        }
+        installer.finish();
+
+        genv
+    }
+
+    /// Helper: get the type string for a vertex ID (checks both Vertex and Source)
+    fn get_type_show(genv: &GlobalEnv, vtx: VertexId) -> String {
+        if let Some(vertex) = genv.get_vertex(vtx) {
+            vertex.show()
+        } else if let Some(source) = genv.get_source(vtx) {
+            source.ty.show()
+        } else {
+            panic!("vertex {:?} not found as either Vertex or Source", vtx);
+        }
+    }
+
+    // Test 1: Receiverless method call type resolution
+    #[test]
+    fn test_implicit_self_call_type_resolution() {
+        let source = r#"
+class User
+  def name
+    "Alice"
+  end
+
+  def greet
+    name
+  end
+end
+"#;
+        let genv = analyze(source);
+
+        // User#greet should resolve to String via User#name
+        let info = genv
+            .resolve_method(&Type::instance("User"), "greet")
+            .expect("User#greet should be registered");
+        assert!(info.return_vertex.is_some());
+
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "String");
+    }
+
+    // Test 2: Receiverless method call with arguments
+    #[test]
+    fn test_implicit_self_call_with_arguments() {
+        let source = r#"
+class Calculator
+  def add(x, y)
+    x
+  end
+
+  def compute
+    add(1, 2)
+  end
+end
+"#;
+        let genv = analyze(source);
+
+        // Calculator#compute should resolve via Calculator#add
+        let info = genv
+            .resolve_method(&Type::instance("Calculator"), "compute")
+            .expect("Calculator#compute should be registered");
+        assert!(info.return_vertex.is_some());
+
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "Integer");
+    }
+
+    // Test 3: Receiverless call in nested class
+    #[test]
+    fn test_implicit_self_call_in_nested_class() {
+        let source = r#"
+module Api
+  module V1
+    class User
+      def name
+        "Alice"
+      end
+
+      def greet
+        name
+      end
+    end
+  end
+end
+"#;
+        let genv = analyze(source);
+
+        // Method registered with simple class name "User" (current behavior of definitions.rs)
+        let info = genv
+            .resolve_method(&Type::instance("User"), "greet")
+            .expect("User#greet should be registered");
+        assert!(info.return_vertex.is_some());
+
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "String");
+    }
+
+    // Test 4: Receiverless call in module
+    #[test]
+    fn test_implicit_self_call_in_module() {
+        let source = r#"
+module Utils
+  def self.format(value)
+    value
+  end
+
+  def self.run
+    format("test")
+  end
+end
+"#;
+        let genv = analyze(source);
+
+        // Utils.run should be registered
+        let info = genv
+            .resolve_method(&Type::instance("Utils"), "run")
+            .expect("Utils#run should be registered");
+        assert!(info.return_vertex.is_some());
+    }
+
+    // Test 5: Receiverless call from within block
+    #[test]
+    fn test_implicit_self_call_from_block() {
+        let source = r#"
+class User
+  def name
+    "Alice"
+  end
+
+  def greet
+    [1].each { name }
+  end
+end
+"#;
+        let genv = analyze(source);
+
+        // User#name should be registered and resolve to String
+        let name_info = genv
+            .resolve_method(&Type::instance("User"), "name")
+            .expect("User#name should be registered");
+        assert!(name_info.return_vertex.is_some());
+        assert_eq!(get_type_show(&genv, name_info.return_vertex.unwrap()), "String");
+
+        // User#greet should also be registered (block contains implicit self call)
+        let greet_info = genv
+            .resolve_method(&Type::instance("User"), "greet")
+            .expect("User#greet should be registered");
+        assert!(greet_info.return_vertex.is_some());
+    }
+
+    // Test 6: Top-level receiverless call (Object receiver)
+    #[test]
+    fn test_implicit_self_call_at_top_level() {
+        let source = r#"
+def helper
+  "result"
+end
+
+helper
+"#;
+        let genv = analyze(source);
+
+        // Should not panic; top-level call uses Object as receiver type
+        // NOTE: top-level def is not registered in method_registry yet,
+        // so this will produce a type error (false positive).
+        // The important thing is that it doesn't panic.
+        // No panic is the real assertion - top-level call should be processed without error
+        let _ = genv;
+    }
+
+    // Test 7: attr_* methods are skipped by dispatch_needs_child
+    #[test]
+    fn test_attr_reader_skipped() {
+        let source = r#"
+class User
+  attr_reader :name
+
+  def greet
+    "hello"
+  end
+end
+"#;
+        let genv = analyze(source);
+
+        // attr_reader should be skipped without panic, and other methods should work
+        let info = genv
+            .resolve_method(&Type::instance("User"), "greet")
+            .expect("User#greet should be registered");
+        assert!(info.return_vertex.is_some());
+
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "String");
+    }
+
+    // Test 8: super call independence (SuperNode is not CallNode)
+    #[test]
+    fn test_super_call_independence() {
+        let source = r#"
+class Base
+  def greet
+    "hello"
+  end
+end
+
+class Child < Base
+  def greet
+    super
+  end
+end
+"#;
+        let genv = analyze(source);
+
+        // super is a SuperNode, not a CallNode, so ImplicitSelfCall should not be triggered.
+        // Base#greet should still work.
+        let info = genv
+            .resolve_method(&Type::instance("Base"), "greet")
+            .expect("Base#greet should be registered");
+        assert!(info.return_vertex.is_some());
+
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "String");
+    }
 }

--- a/test/implicit_self_call_test.rb
+++ b/test/implicit_self_call_test.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ImplicitSelfCallTest < Minitest::Test
+  include CLITestHelper
+
+  # ============================================
+  # No Error
+  # ============================================
+
+  def test_receiverless_method_call
+    source = <<~RUBY
+      class User
+        def name
+          "Alice"
+        end
+
+        def greet
+          name.upcase
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_receiverless_method_call_with_arguments
+    source = <<~RUBY
+      class Greeter
+        def greet(name)
+          name.upcase
+        end
+
+        def run
+          greet("Alice")
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_receiverless_call_chain
+    source = <<~RUBY
+      class Formatter
+        def title
+          "hello"
+        end
+
+        def format
+          title.upcase.downcase
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_receiverless_call_in_nested_class
+    source = <<~RUBY
+      module Api
+        class User
+          def name
+            "Alice"
+          end
+
+          def greet
+            name.upcase
+          end
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_attr_reader_does_not_panic
+    source = <<~RUBY
+      class User
+        attr_reader :name
+
+        def greet
+          "hello"
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_super_does_not_panic
+    source = <<~RUBY
+      class Base
+        def greet
+          "hello"
+        end
+      end
+
+      class Child < Base
+        def greet
+          super
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_param_type_propagation_via_implicit_self
+    source = <<~RUBY
+      class Calculator
+        def add(x, y)
+          x.even?
+        end
+
+        def compute
+          add(1, 2)
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  # ============================================
+  # Error Detection
+  # ============================================
+
+  def test_receiverless_method_return_type_error
+    source = <<~RUBY
+      class User
+        def name
+          "Alice"
+        end
+
+        def greet
+          name.even?
+        end
+      end
+    RUBY
+
+    assert_check_error(source, method_name: 'even?', receiver_type: 'String')
+  end
+
+  def test_receiverless_method_return_integer_type_error
+    source = <<~RUBY
+      class Calculator
+        def answer
+          42
+        end
+
+        def compute
+          answer.upcase
+        end
+      end
+    RUBY
+
+    assert_check_error(source, method_name: 'upcase', receiver_type: 'Integer')
+  end
+
+  def test_param_type_propagation_error_via_implicit_self
+    source = <<~RUBY
+      class Processor
+        def process(value)
+          value.upcase
+        end
+
+        def run
+          process(42)
+        end
+      end
+    RUBY
+
+    assert_check_error(source, method_name: 'upcase', receiver_type: 'Integer')
+  end
+end


### PR DESCRIPTION
Ruby methods are frequently called without an explicit receiver (e.g., `name` instead of `self.name`). Without handling these, many method return types could not be resolved by the type inference engine.

## Changes:
- Add ImplicitSelfCall variant to NeedsChildKind
- Dispatch receiver-less CallNode as ImplicitSelfCall, synthesizing an implicit self receiver from the current class/module scope (falls back to Object at top-level)
- Skip attr_reader/attr_writer/attr_accessor (deferred to next phase)
- Extract process_method_call_common to share logic between MethodCall and ImplicitSelfCall
- Hoist block/arguments extraction before receiver branch to eliminate duplication
- Add 8 tests covering: basic resolution, arguments, nested class, module, block scope, top-level, attr_* skip, and super independence