### PR TITLE
Add attr_reader/attr_writer/attr_accessor support for type inference

### DIFF
--- a/rust/src/analyzer/attributes.rs
+++ b/rust/src/analyzer/attributes.rs
@@ -1,0 +1,57 @@
+//! Attribute accessor support - synthesize getter/setter methods for attr_reader/attr_writer/attr_accessor
+
+use crate::env::GlobalEnv;
+use crate::types::Type;
+
+use super::dispatch::AttrKind;
+
+/// Register synthesized getter/setter methods for attr_reader/attr_writer/attr_accessor.
+///
+/// - attr_reader :name → registers User#name (getter, return = @name vertex)
+/// - attr_writer :name → registers User#name= (setter, param → @name edge)
+/// - attr_accessor :name → registers both getter and setter
+///
+/// If @name has no VertexId yet, one is pre-allocated so that later assignments
+/// (e.g., `@name = "Alice"` in initialize) propagate into the same vertex.
+pub(crate) fn process_attr_declaration(
+    genv: &mut GlobalEnv,
+    kind: AttrKind,
+    attr_names: Vec<String>,
+) {
+    let Some(class_name) = genv.scope_manager.current_class_name() else {
+        return;
+    };
+    let recv_ty = Type::instance(&class_name);
+
+    for attr_name in attr_names {
+        let ivar_name = format!("@{}", attr_name);
+
+        // Get or pre-allocate VertexId for @name
+        let ivar_vtx = match genv.scope_manager.lookup_instance_var(&ivar_name) {
+            Some(vtx) => vtx,
+            None => {
+                let vtx = genv.new_vertex();
+                genv.scope_manager
+                    .set_instance_var_in_class(ivar_name, vtx);
+                vtx
+            }
+        };
+
+        // Register getter (attr_reader / attr_accessor)
+        if matches!(kind, AttrKind::Reader | AttrKind::Accessor) {
+            genv.register_user_method(recv_ty.clone(), &attr_name, ivar_vtx, vec![]);
+        }
+
+        // Register setter (attr_writer / attr_accessor)
+        if matches!(kind, AttrKind::Writer | AttrKind::Accessor) {
+            let param_vtx = genv.new_vertex();
+            genv.add_edge(param_vtx, ivar_vtx);
+            genv.register_user_method(
+                recv_ty.clone(),
+                &format!("{}=", attr_name),
+                ivar_vtx,
+                vec![param_vtx],
+            );
+        }
+    }
+}

--- a/rust/src/analyzer/dispatch.rs
+++ b/rust/src/analyzer/dispatch.rs
@@ -15,6 +15,14 @@ use super::variables::{
     install_self,
 };
 
+/// Kind of attr_* declaration
+#[derive(Debug, Clone, Copy)]
+pub enum AttrKind {
+    Reader,
+    Writer,
+    Accessor,
+}
+
 /// Result of dispatching a simple node (no child processing needed)
 pub enum DispatchResult {
     /// Node produced a vertex
@@ -45,6 +53,11 @@ pub enum NeedsChildKind<'a> {
         location: SourceLocation,
         block: Option<Node<'a>>,
         arguments: Vec<Node<'a>>,
+    },
+    /// attr_reader / attr_writer / attr_accessor declaration
+    AttrDeclaration {
+        kind: AttrKind,
+        attr_names: Vec<String>,
     },
 }
 
@@ -77,6 +90,23 @@ pub fn dispatch_simple(genv: &mut GlobalEnv, lenv: &mut LocalEnv, node: &Node) -
     }
 
     DispatchResult::NotHandled
+}
+
+/// Extract symbol names from attr_* arguments (e.g., `attr_reader :name, :email`)
+fn extract_symbol_names(call_node: &ruby_prism::CallNode) -> Vec<String> {
+    call_node
+        .arguments()
+        .map(|args| {
+            args.arguments()
+                .iter()
+                .filter_map(|arg| {
+                    arg.as_symbol_node().map(|sym| {
+                        String::from_utf8_lossy(&sym.unescaped()).to_string()
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Check if node needs child processing
@@ -126,9 +156,16 @@ pub fn dispatch_needs_child<'a>(node: &Node<'a>, source: &str) -> Option<NeedsCh
         } else {
             // No receiver: implicit self method call (e.g., `name`, `puts "hello"`)
 
-            // TODO: attr_* methods will be handled in next phase (skip for now)
-            const ATTR_METHODS: &[&str] = &["attr_reader", "attr_writer", "attr_accessor"];
-            if ATTR_METHODS.contains(&method_name.as_str()) {
+            if let Some(kind) = match method_name.as_str() {
+                "attr_reader" => Some(AttrKind::Reader),
+                "attr_writer" => Some(AttrKind::Writer),
+                "attr_accessor" => Some(AttrKind::Accessor),
+                _ => None,
+            } {
+                let attr_names = extract_symbol_names(&call_node);
+                if !attr_names.is_empty() {
+                    return Some(NeedsChildKind::AttrDeclaration { kind, attr_names });
+                }
                 return None;
             }
 
@@ -202,6 +239,10 @@ pub(crate) fn process_needs_child(
             process_method_call_common(
                 genv, lenv, changes, source, recv_vtx, method_name, location, block, arguments,
             )
+        }
+        NeedsChildKind::AttrDeclaration { kind, attr_names } => {
+            super::attributes::process_attr_declaration(genv, kind, attr_names);
+            None
         }
     }
 }
@@ -466,10 +507,30 @@ helper
         let _ = genv;
     }
 
-    // Test 7: attr_* methods are skipped by dispatch_needs_child
+    // Test 7: attr_reader basic — getter type resolution
     #[test]
-    fn test_attr_reader_skipped() {
+    fn test_attr_reader_basic() {
         let source = r#"
+class User
+  attr_reader :name
+
+  def initialize
+    @name = "Alice"
+  end
+end
+"#;
+        let genv = analyze(source);
+
+        // User#name should be registered and resolve to String via @name
+        let info = genv
+            .resolve_method(&Type::instance("User"), "name")
+            .expect("User#name should be registered");
+        assert!(info.return_vertex.is_some());
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "String");
+
+        // Other methods still work
+        let greet_src = r#"
 class User
   attr_reader :name
 
@@ -478,19 +539,182 @@ class User
   end
 end
 "#;
+        let genv2 = analyze(greet_src);
+        let info2 = genv2
+            .resolve_method(&Type::instance("User"), "greet")
+            .expect("User#greet should be registered");
+        assert_eq!(get_type_show(&genv2, info2.return_vertex.unwrap()), "String");
+    }
+
+    // Test 8: attr_reader + self.name method call
+    #[test]
+    fn test_attr_reader_with_self_call() {
+        let source = r#"
+class User
+  attr_reader :name
+
+  def initialize
+    @name = "Alice"
+  end
+
+  def greet
+    self.name
+  end
+end
+"#;
         let genv = analyze(source);
 
-        // attr_reader should be skipped without panic, and other methods should work
+        // User#greet should resolve to String via User#name → @name
         let info = genv
             .resolve_method(&Type::instance("User"), "greet")
             .expect("User#greet should be registered");
         assert!(info.return_vertex.is_some());
-
         let ret_vtx = info.return_vertex.unwrap();
         assert_eq!(get_type_show(&genv, ret_vtx), "String");
     }
 
-    // Test 8: super call independence (SuperNode is not CallNode)
+    // Test 9: attr_reader + receiverless name call (proposal D integration)
+    #[test]
+    fn test_attr_reader_receiverless_call() {
+        let source = r#"
+class User
+  attr_reader :name
+
+  def initialize
+    @name = "Alice"
+  end
+
+  def greet
+    name
+  end
+end
+"#;
+        let genv = analyze(source);
+
+        // User#greet should resolve to String via implicit self → User#name → @name
+        let info = genv
+            .resolve_method(&Type::instance("User"), "greet")
+            .expect("User#greet should be registered");
+        assert!(info.return_vertex.is_some());
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "String");
+    }
+
+    // Test 10: attr_accessor — both getter and setter
+    #[test]
+    fn test_attr_accessor() {
+        let source = r#"
+class User
+  attr_accessor :age
+
+  def initialize
+    @age = 30
+  end
+end
+"#;
+        let genv = analyze(source);
+
+        // User#age (getter) should be registered and resolve to Integer
+        let getter = genv
+            .resolve_method(&Type::instance("User"), "age")
+            .expect("User#age getter should be registered");
+        assert!(getter.return_vertex.is_some());
+        assert_eq!(get_type_show(&genv, getter.return_vertex.unwrap()), "Integer");
+
+        // User#age= (setter) should also be registered
+        let setter = genv
+            .resolve_method(&Type::instance("User"), "age=")
+            .expect("User#age= setter should be registered");
+        assert!(setter.return_vertex.is_some());
+    }
+
+    // Test 11: multiple attributes in single declaration
+    #[test]
+    fn test_attr_reader_multiple() {
+        let source = r#"
+class User
+  attr_reader :name, :email
+
+  def initialize
+    @name = "Alice"
+    @email = "alice@test.com"
+  end
+end
+"#;
+        let genv = analyze(source);
+
+        let name_info = genv
+            .resolve_method(&Type::instance("User"), "name")
+            .expect("User#name should be registered");
+        assert_eq!(get_type_show(&genv, name_info.return_vertex.unwrap()), "String");
+
+        let email_info = genv
+            .resolve_method(&Type::instance("User"), "email")
+            .expect("User#email should be registered");
+        assert_eq!(get_type_show(&genv, email_info.return_vertex.unwrap()), "String");
+    }
+
+    // Test 12: attr_reader in nested class
+    #[test]
+    fn test_attr_reader_nested_class() {
+        let source = r#"
+module Api
+  class User
+    attr_reader :name
+
+    def initialize
+      @name = "Alice"
+    end
+  end
+end
+"#;
+        let genv = analyze(source);
+
+        // Registered with simple class name "User"
+        let info = genv
+            .resolve_method(&Type::instance("User"), "name")
+            .expect("User#name should be registered");
+        assert!(info.return_vertex.is_some());
+        assert_eq!(get_type_show(&genv, info.return_vertex.unwrap()), "String");
+    }
+
+    // Test 13: attr_writer only — setter registered, getter not
+    #[test]
+    fn test_attr_writer_only() {
+        let source = r#"
+class User
+  attr_writer :name
+end
+"#;
+        let genv = analyze(source);
+
+        // User#name= should be registered
+        let setter = genv.resolve_method(&Type::instance("User"), "name=");
+        assert!(setter.is_some(), "User#name= should be registered");
+
+        // User#name (getter) should NOT be registered
+        let getter = genv.resolve_method(&Type::instance("User"), "name");
+        assert!(getter.is_none(), "User#name getter should NOT be registered for attr_writer");
+    }
+
+    // Test 14: attr_reader with no assignment (empty vertex)
+    #[test]
+    fn test_attr_reader_unassigned() {
+        let source = r#"
+class User
+  attr_reader :unknown
+end
+"#;
+        let genv = analyze(source);
+
+        // User#unknown should be registered (with empty vertex)
+        let info = genv
+            .resolve_method(&Type::instance("User"), "unknown")
+            .expect("User#unknown should be registered");
+        assert!(info.return_vertex.is_some());
+    }
+
+    // Test 15: super call independence (SuperNode is not CallNode)
     #[test]
     fn test_super_call_independence() {
         let source = r#"

--- a/rust/src/analyzer/mod.rs
+++ b/rust/src/analyzer/mod.rs
@@ -1,3 +1,4 @@
+mod attributes;
 mod blocks;
 mod calls;
 mod definitions;

--- a/rust/src/analyzer/variables.rs
+++ b/rust/src/analyzer/variables.rs
@@ -29,14 +29,23 @@ pub fn install_local_var_read(lenv: &LocalEnv, var_name: &str) -> Option<VertexI
 }
 
 /// Install instance variable write: @name = value
+///
+/// If @name already has a pre-allocated VertexId (e.g., from attr_reader),
+/// an edge is added from value_vtx to the existing vertex so types propagate.
+/// Otherwise, value_vtx is registered directly as the ivar's VertexId.
 pub fn install_ivar_write(
     genv: &mut GlobalEnv,
     ivar_name: String,
     value_vtx: VertexId,
 ) -> VertexId {
-    genv.scope_manager
-        .set_instance_var_in_class(ivar_name, value_vtx);
-    value_vtx
+    if let Some(existing_vtx) = genv.scope_manager.lookup_instance_var(&ivar_name) {
+        genv.add_edge(value_vtx, existing_vtx);
+        existing_vtx
+    } else {
+        genv.scope_manager
+            .set_instance_var_in_class(ivar_name, value_vtx);
+        value_vtx
+    }
 }
 
 /// Install instance variable read: @name

--- a/test/attr_test.rb
+++ b/test/attr_test.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AttrTest < Minitest::Test
+  include CLITestHelper
+
+  # ============================================
+  # No Error
+  # ============================================
+
+  def test_attr_reader_with_self_call
+    source = <<~RUBY
+      class User
+        attr_reader :name
+
+        def initialize
+          @name = "Alice"
+        end
+
+        def greet
+          self.name.upcase
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_attr_reader_with_receiverless_call
+    source = <<~RUBY
+      class User
+        attr_reader :name
+
+        def initialize
+          @name = "Alice"
+        end
+
+        def greet
+          name.upcase
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_attr_accessor_getter
+    source = <<~RUBY
+      class User
+        attr_accessor :age
+
+        def initialize
+          @age = 30
+        end
+
+        def check
+          self.age.even?
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_attr_reader_multiple_attributes
+    source = <<~RUBY
+      class User
+        attr_reader :name, :email
+
+        def initialize
+          @name = "Alice"
+          @email = "alice@test.com"
+        end
+
+        def display
+          self.name.upcase
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_attr_reader_before_initialize
+    source = <<~RUBY
+      class User
+        attr_reader :name
+
+        def initialize
+          @name = "Alice"
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  # ============================================
+  # Error Detection
+  # ============================================
+
+  def test_attr_reader_getter_type_error
+    source = <<~RUBY
+      class User
+        attr_reader :name
+
+        def initialize
+          @name = "Alice"
+        end
+
+        def greet
+          self.name.even?
+        end
+      end
+    RUBY
+
+    assert_check_error(source, method_name: 'even?', receiver_type: 'String')
+  end
+
+  def test_attr_reader_receiverless_type_error
+    source = <<~RUBY
+      class User
+        attr_reader :age
+
+        def initialize
+          @age = 30
+        end
+
+        def check
+          age.upcase
+        end
+      end
+    RUBY
+
+    assert_check_error(source, method_name: 'upcase', receiver_type: 'Integer')
+  end
+
+  def test_attr_accessor_getter_type_error
+    source = <<~RUBY
+      class User
+        attr_accessor :count
+
+        def initialize
+          @count = 10
+        end
+
+        def display
+          self.count.upcase
+        end
+      end
+    RUBY
+
+    assert_check_error(source, method_name: 'upcase', receiver_type: 'Integer')
+  end
+end


### PR DESCRIPTION
Ruby's attr_* declarations were previously skipped, causing type resolution to fail when getter/setter methods (e.g., `self.name` or receiverless `name`) were called on attributes.

This change synthesizes getter/setter methods from attr_* declarations and registers them in the MethodRegistry. A pre-allocation strategy is used for instance variable vertices so that attr_reader can appear before initialize — later assignments (`@name = "Alice"`) propagate types into the same vertex via edges.