### PR TITLE
Add ConstantReadNode/ConstantPathNode support for type inference

### DIFF
--- a/rust/src/analyzer/definitions.rs
+++ b/rust/src/analyzer/definitions.rs
@@ -142,7 +142,7 @@ fn extract_module_name(module_node: &ruby_prism::ModuleNode) -> String {
 /// - `Api::User` (ConstantPathNode) → "Api::User"
 /// - `Api::V1::User` (nested ConstantPathNode) → "Api::V1::User"
 /// - `::Api::User` (absolute path with COLON3) → "Api::User"
-fn extract_constant_path(node: &Node) -> Option<String> {
+pub(crate) fn extract_constant_path(node: &Node) -> Option<String> {
     // Simple constant read: `User`
     if let Some(constant_read) = node.as_constant_read_node() {
         return Some(String::from_utf8_lossy(constant_read.name().as_slice()).to_string());

--- a/rust/src/analyzer/dispatch.rs
+++ b/rust/src/analyzer/dispatch.rs
@@ -89,6 +89,21 @@ pub fn dispatch_simple(genv: &mut GlobalEnv, lenv: &mut LocalEnv, node: &Node) -
         };
     }
 
+    // ConstantReadNode: User → Type::Singleton("User")
+    if let Some(const_read) = node.as_constant_read_node() {
+        let name = String::from_utf8_lossy(const_read.name().as_slice()).to_string();
+        let vtx = genv.new_source(Type::singleton(&name));
+        return DispatchResult::Vertex(vtx);
+    }
+
+    // ConstantPathNode: Api::User → Type::Singleton("Api::User")
+    if node.as_constant_path_node().is_some() {
+        if let Some(name) = super::definitions::extract_constant_path(node) {
+            let vtx = genv.new_source(Type::singleton(&name));
+            return DispatchResult::Vertex(vtx);
+        }
+    }
+
     DispatchResult::NotHandled
 }
 
@@ -741,5 +756,122 @@ end
 
         let ret_vtx = info.return_vertex.unwrap();
         assert_eq!(get_type_show(&genv, ret_vtx), "String");
+    }
+
+    // Test 16: User.new → instance(User)
+    #[test]
+    fn test_constant_read_user_new() {
+        let source = r#"
+class User
+  def name
+    "Alice"
+  end
+end
+
+x = User.new
+"#;
+        let genv = analyze(source);
+        assert!(
+            genv.type_errors.is_empty(),
+            "User.new should not produce type errors: {:?}",
+            genv.type_errors
+        );
+    }
+
+    // Test 17: User.new.name → String
+    #[test]
+    fn test_constant_read_user_new_method_chain() {
+        let source = r#"
+class User
+  def name
+    "Alice"
+  end
+end
+
+x = User.new.name
+"#;
+        let genv = analyze(source);
+        assert!(
+            genv.type_errors.is_empty(),
+            "User.new.name should not produce type errors: {:?}",
+            genv.type_errors
+        );
+    }
+
+    // Test 18: Api::User.new → instance(Api::User) (ConstantPathNode)
+    #[test]
+    fn test_constant_path_qualified_new() {
+        let source = r#"
+class Api::User
+  def name
+    "Alice"
+  end
+end
+
+x = Api::User.new
+"#;
+        let genv = analyze(source);
+        assert!(
+            genv.type_errors.is_empty(),
+            "Api::User.new should not produce type errors: {:?}",
+            genv.type_errors
+        );
+    }
+
+    // Test 19: User.new("Alice") → initialize parameter propagation
+    #[test]
+    fn test_constant_read_new_with_initialize_params() {
+        let source = r#"
+class User
+  def initialize(name)
+    @name = name
+  end
+end
+
+x = User.new("Alice")
+"#;
+        let genv = analyze(source);
+        assert!(genv.type_errors.is_empty());
+    }
+
+    // Test 20: user = User.new; user.name → String
+    #[test]
+    fn test_constant_read_assign_and_call() {
+        let source = r#"
+class User
+  def name
+    "Alice"
+  end
+end
+
+user = User.new
+user.name
+"#;
+        let genv = analyze(source);
+        assert!(
+            genv.type_errors.is_empty(),
+            "user = User.new; user.name should not produce type errors: {:?}",
+            genv.type_errors
+        );
+    }
+
+    // Test 21: User.some_method should not produce type error (Singleton error suppression)
+    #[test]
+    fn test_constant_read_no_false_positive() {
+        let source = r#"
+class User
+  def name
+    "Alice"
+  end
+end
+
+User.some_method
+"#;
+        let genv = analyze(source);
+        assert!(
+            genv.type_errors.is_empty(),
+            "User.some_method should not produce type errors (Singleton suppression): {:?}",
+            genv.type_errors
+        );
     }
 }

--- a/rust/src/graph/box.rs
+++ b/rust/src/graph/box.rs
@@ -106,6 +106,35 @@ impl BoxTrait for MethodCallBox {
                     let ret_src_id = genv.new_source(method_info.return_type.clone());
                     changes.add_edge(ret_src_id, self.ret);
                 }
+            } else if self.method_name == "new" {
+                if let Type::Singleton { name } = &recv_ty {
+                    // singleton(User)#new → instance(User)
+                    let instance_type = Type::instance(name.full_name());
+                    let ret_src = genv.new_source(instance_type.clone());
+                    changes.add_edge(ret_src, self.ret);
+
+                    // Propagate arguments to initialize parameters
+                    if let Some(init_info) = genv.resolve_method(&instance_type, "initialize") {
+                        if let Some(param_vtxs) = &init_info.param_vertices {
+                            for (i, param_vtx) in param_vtxs.iter().enumerate() {
+                                if let Some(arg_vtx) = self.arg_vtxs.get(i) {
+                                    changes.add_edge(*arg_vtx, *param_vtx);
+                                }
+                            }
+                        }
+                    }
+                    continue;
+                }
+                // Non-singleton .new: record error
+                genv.record_type_error(
+                    recv_ty.clone(),
+                    self.method_name.clone(),
+                    self.location.clone(),
+                );
+            } else if matches!(&recv_ty, Type::Singleton { .. }) {
+                // Skip error for unknown class methods on Singleton types
+                // (class method RBS registration is not yet supported)
+                continue;
             } else {
                 // Record type error for diagnostic reporting
                 genv.record_type_error(

--- a/test/constant_read_test.rb
+++ b/test/constant_read_test.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ConstantReadTest < Minitest::Test
+  include CLITestHelper
+
+  # ============================================
+  # No Error
+  # ============================================
+
+  def test_user_new_method_call
+    source = <<~RUBY
+      class User
+        def name
+          "Alice"
+        end
+      end
+
+      User.new.name.upcase
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_user_new_assign_then_call
+    source = <<~RUBY
+      class User
+        def name
+          "Alice"
+        end
+      end
+
+      user = User.new
+      user.name.upcase
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_user_new_with_attr_reader
+    source = <<~RUBY
+      class User
+        attr_reader :name
+
+        def initialize
+          @name = "Alice"
+        end
+      end
+
+      user = User.new
+      user.name.upcase
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_user_new_with_initialize_and_ivar
+    source = <<~RUBY
+      class User
+        attr_reader :name
+
+        def initialize(name)
+          @name = name
+        end
+      end
+
+      user = User.new("Alice")
+      user.name.upcase
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  # ============================================
+  # Error Detection
+  # ============================================
+
+  def test_user_new_method_chain_type_error
+    source = <<~RUBY
+      class User
+        def name
+          "Alice"
+        end
+      end
+
+      User.new.name.even?
+    RUBY
+
+    assert_check_error(source, method_name: 'even?', receiver_type: 'String')
+  end
+
+  def test_user_new_with_attr_type_error
+    source = <<~RUBY
+      class User
+        attr_reader :age
+
+        def initialize
+          @age = 30
+        end
+      end
+
+      User.new.age.upcase
+    RUBY
+
+    assert_check_error(source, method_name: 'upcase', receiver_type: 'Integer')
+  end
+end


### PR DESCRIPTION
Enable type inference for `User.new` patterns by introducing Singleton type handling. ConstantReadNode/ConstantPathNode now produce Type::Singleton in dispatch_simple, and MethodCallBox resolves singleton(X)#new to instance(X) with initialize parameter propagation. Suppress false positive errors for unknown class methods on Singleton types since class method RBS registration is not yet supported.