### PR TITLE
Support string interpolation type inference to eliminate false positives

### DIFF
--- a/rust/src/analyzer/literals.rs
+++ b/rust/src/analyzer/literals.rs
@@ -34,6 +34,30 @@ pub(crate) fn install_literal_node(
         return install_range_literal(genv, lenv, changes, source, &range_node);
     }
 
+    // InterpolatedStringNode: "Hello, #{expr}" → String
+    if let Some(interp) = node.as_interpolated_string_node() {
+        for part in &interp.parts() {
+            super::install::install_node(genv, lenv, changes, source, &part);
+        }
+        return Some(genv.new_source(Type::string()));
+    }
+
+    // InterpolatedSymbolNode: :"hello_#{expr}" → Symbol
+    if let Some(interp) = node.as_interpolated_symbol_node() {
+        for part in &interp.parts() {
+            super::install::install_node(genv, lenv, changes, source, &part);
+        }
+        return Some(genv.new_source(Type::symbol()));
+    }
+
+    // InterpolatedRegularExpressionNode: /hello #{expr}/ → Regexp
+    if let Some(interp) = node.as_interpolated_regular_expression_node() {
+        for part in &interp.parts() {
+            super::install::install_node(genv, lenv, changes, source, &part);
+        }
+        return Some(genv.new_source(Type::regexp()));
+    }
+
     install_simple_literal(genv, node)
 }
 
@@ -242,6 +266,27 @@ mod tests {
 
     #[test]
     fn test_install_regexp_literal() {
+        let mut genv = GlobalEnv::new();
+        let vtx = genv.new_source(Type::regexp());
+        assert_eq!(genv.get_source(vtx).unwrap().ty.show(), "Regexp");
+    }
+
+    #[test]
+    fn test_install_interpolated_string_literal() {
+        let mut genv = GlobalEnv::new();
+        let vtx = genv.new_source(Type::string());
+        assert_eq!(genv.get_source(vtx).unwrap().ty.show(), "String");
+    }
+
+    #[test]
+    fn test_install_interpolated_symbol_literal() {
+        let mut genv = GlobalEnv::new();
+        let vtx = genv.new_source(Type::symbol());
+        assert_eq!(genv.get_source(vtx).unwrap().ty.show(), "Symbol");
+    }
+
+    #[test]
+    fn test_install_interpolated_regexp_literal() {
         let mut genv = GlobalEnv::new();
         let vtx = genv.new_source(Type::regexp());
         assert_eq!(genv.get_source(vtx).unwrap().ty.show(), "Regexp");

--- a/test/regexp_test.rb
+++ b/test/regexp_test.rb
@@ -47,4 +47,16 @@ class RegexpTest < Minitest::Test
 
     assert_check_error(source, method_name: 'upcase', receiver_type: 'Regexp')
   end
+
+  def test_interpolated_regexp_type_error
+    source = <<~RUBY
+      class Formatter
+        def format
+          x = /hello \#{1}/
+          y = x.ceil
+        end
+      end
+    RUBY
+    assert_check_error(source, method_name: 'ceil', receiver_type: 'Regexp')
+  end
 end

--- a/test/string_test.rb
+++ b/test/string_test.rb
@@ -33,6 +33,10 @@ class StringTest < Minitest::Test
     assert_equal "String", types["y"]
   end
 
+  def test_interpolated_string_literal
+    assert_type 'x = "hello #{1 + 2}"', "x", "String"
+  end
+
   # ============================================
   # No Error
   # ============================================
@@ -43,6 +47,14 @@ class StringTest < Minitest::Test
       y = x.upcase.downcase
     RUBY
 
+    assert_no_check_errors(source)
+  end
+
+  def test_interpolated_string_method_chain_no_error
+    source = <<~RUBY
+      x = "hello \#{name}"
+      y = x.upcase.downcase
+    RUBY
     assert_no_check_errors(source)
   end
 
@@ -62,4 +74,17 @@ class StringTest < Minitest::Test
 
     assert_check_error(source, method_name: 'ceil', receiver_type: 'String')
   end
+
+  def test_interpolated_string_type_error
+    source = <<~RUBY
+      class Formatter
+        def format
+          x = "hello \#{1}"
+          y = x.ceil
+        end
+      end
+    RUBY
+    assert_check_error(source, method_name: 'ceil', receiver_type: 'String')
+  end
+
 end

--- a/test/symbol_test.rb
+++ b/test/symbol_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SymbolTest < Minitest::Test
+  include CLITestHelper
+
+  # ============================================
+  # Error Detection
+  # ============================================
+
+  def test_interpolated_symbol_type_error
+    source = <<~RUBY
+      class Formatter
+        def format
+          x = :"hello_\#{1}"
+          y = x.ceil
+        end
+      end
+    RUBY
+    assert_check_error(source, method_name: 'ceil', receiver_type: 'Symbol')
+  end
+end


### PR DESCRIPTION
InterpolatedStringNode, InterpolatedSymbolNode, InterpolatedRegularExpressionNode were unhandled, causing unknown types for interpolated literals and false positive errors on subsequent method calls (e.g. "hello #{name}".upcase).