### PR TITLE
Support ParenthesesNode type inference to resolve parenthesized expressions

### DIFF
--- a/rust/src/analyzer/install.rs
+++ b/rust/src/analyzer/install.rs
@@ -13,6 +13,7 @@ use super::conditionals::{process_case_node, process_if_node, process_unless_nod
 use super::definitions::{process_class_node, process_def_node, process_module_node};
 use super::dispatch::{dispatch_needs_child, dispatch_simple, process_needs_child, DispatchResult};
 use super::literals::install_literal_node;
+use super::parentheses::process_parentheses_node;
 
 /// Build graph from AST (public API wrapper)
 pub struct AstInstaller<'a> {
@@ -74,6 +75,10 @@ pub(crate) fn install_node(
     }
     if let Some(case_node) = node.as_case_node() {
         return process_case_node(genv, lenv, changes, source, &case_node);
+    }
+
+    if let Some(paren_node) = node.as_parentheses_node() {
+        return process_parentheses_node(genv, lenv, changes, source, &paren_node);
     }
 
     match dispatch_simple(genv, lenv, node) {

--- a/rust/src/analyzer/mod.rs
+++ b/rust/src/analyzer/mod.rs
@@ -7,6 +7,7 @@ mod dispatch;
 mod install;
 mod literals;
 mod parameters;
+mod parentheses;
 mod variables;
 
 pub use install::AstInstaller;

--- a/rust/src/analyzer/parentheses.rs
+++ b/rust/src/analyzer/parentheses.rs
@@ -1,0 +1,113 @@
+//! Parentheses - pass-through type propagation for parenthesized expressions
+
+use crate::env::{GlobalEnv, LocalEnv};
+use crate::graph::{ChangeSet, VertexId};
+
+use super::install::{install_node, install_statements};
+
+/// Process ParenthesesNode: propagate inner expression's type
+pub(crate) fn process_parentheses_node(
+    genv: &mut GlobalEnv,
+    lenv: &mut LocalEnv,
+    changes: &mut ChangeSet,
+    source: &str,
+    paren_node: &ruby_prism::ParenthesesNode,
+) -> Option<VertexId> {
+    let body = paren_node.body()?;
+
+    if let Some(stmts) = body.as_statements_node() {
+        // (expr1; expr2) → process all, return last expression's type
+        install_statements(genv, lenv, changes, source, &stmts)
+    } else {
+        // (expr) → propagate inner expression's type directly
+        install_node(genv, lenv, changes, source, &body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::analyzer::install::AstInstaller;
+    use crate::env::{GlobalEnv, LocalEnv};
+    use crate::graph::VertexId;
+    use crate::parser::ParseSession;
+    use crate::types::Type;
+
+    fn analyze(source: &str) -> GlobalEnv {
+        let session = ParseSession::new();
+        let parse_result = session.parse_source(source, "test.rb").unwrap();
+        let root = parse_result.node();
+        let program = root.as_program_node().unwrap();
+
+        let mut genv = GlobalEnv::new();
+        let mut lenv = LocalEnv::new();
+
+        let mut installer = AstInstaller::new(&mut genv, &mut lenv, source);
+        for stmt in &program.statements().body() {
+            installer.install_node(&stmt);
+        }
+        installer.finish();
+
+        genv
+    }
+
+    fn get_type_show(genv: &GlobalEnv, vtx: VertexId) -> String {
+        if let Some(vertex) = genv.get_vertex(vtx) {
+            vertex.show()
+        } else if let Some(source) = genv.get_source(vtx) {
+            source.ty.show()
+        } else {
+            panic!("vertex {:?} not found as either Vertex or Source", vtx);
+        }
+    }
+
+    #[test]
+    fn test_parenthesized_integer() {
+        let source = r#"
+class Foo
+  def bar
+    x = (42)
+  end
+end
+"#;
+        let genv = analyze(source);
+        let info = genv
+            .resolve_method(&Type::instance("Foo"), "bar")
+            .expect("Foo#bar should be registered");
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "Integer");
+    }
+
+    #[test]
+    fn test_parenthesized_string() {
+        let source = r#"
+class Foo
+  def bar
+    x = ("hello")
+  end
+end
+"#;
+        let genv = analyze(source);
+        let info = genv
+            .resolve_method(&Type::instance("Foo"), "bar")
+            .expect("Foo#bar should be registered");
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "String");
+    }
+
+    #[test]
+    fn test_parenthesized_multiple_statements() {
+        let source = r#"
+class Foo
+  def bar
+    x = (a = 1; "hello")
+  end
+end
+"#;
+        let genv = analyze(source);
+        let info = genv
+            .resolve_method(&Type::instance("Foo"), "bar")
+            .expect("Foo#bar should be registered");
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "String");
+    }
+}

--- a/test/parentheses_test.rb
+++ b/test/parentheses_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ParenthesesTest < Minitest::Test
+  include CLITestHelper
+
+  # ============================================
+  # Type Inference
+  # ============================================
+
+  def test_parenthesized_integer
+    assert_type 'x = (42)', "x", "Integer"
+  end
+
+  # ============================================
+  # No Error
+  # ============================================
+
+  def test_parenthesized_string_method_call_no_error
+    source = <<~RUBY
+      x = ("hello")
+      y = x.upcase
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  # ============================================
+  # Error Detection
+  # ============================================
+
+  def test_parenthesized_string_type_error
+    source = <<~RUBY
+      class Formatter
+        def format
+          x = ("hello")
+          y = x.ceil
+        end
+      end
+    RUBY
+
+    assert_check_error(source, method_name: 'ceil', receiver_type: 'String')
+  end
+end


### PR DESCRIPTION
Parenthesized expressions like (42) or ("hello").upcase were unhandled, causing their types to be lost and generating false positive errors.