### PR TITLE
Support qualified name method registration to resolve namespace conflicts

### DIFF
--- a/rust/src/analyzer/attributes.rs
+++ b/rust/src/analyzer/attributes.rs
@@ -18,10 +18,10 @@ pub(crate) fn process_attr_declaration(
     kind: AttrKind,
     attr_names: Vec<String>,
 ) {
-    let Some(class_name) = genv.scope_manager.current_class_name() else {
+    let Some(qualified_name) = genv.scope_manager.current_qualified_name() else {
         return;
     };
-    let recv_ty = Type::instance(&class_name);
+    let recv_ty = Type::instance(&qualified_name);
 
     for attr_name in attr_names {
         let ivar_name = format!("@{}", attr_name);

--- a/rust/src/analyzer/definitions.rs
+++ b/rust/src/analyzer/definitions.rs
@@ -83,10 +83,7 @@ pub(crate) fn process_def_node(
 
     // Register user-defined method with return vertex and param vertices (before exiting scope)
     if let Some(return_vtx) = last_vtx {
-        let recv_type_name = genv
-            .scope_manager
-            .current_class_name()
-            .or_else(|| genv.scope_manager.current_module_name());
+        let recv_type_name = genv.scope_manager.current_qualified_name();
 
         if let Some(name) = recv_type_name {
             genv.register_user_method(
@@ -333,5 +330,94 @@ mod tests {
             .resolve_method(&Type::instance("User"), "name")
             .expect("User#name should be registered");
         assert!(info.return_vertex.is_some());
+    }
+
+    #[test]
+    fn test_qualified_name_method_registration() {
+        let source = r#"
+module Api
+  module V1
+    class User
+      def name
+        "Alice"
+      end
+    end
+  end
+end
+"#;
+        let session = ParseSession::new();
+        let parse_result = session.parse_source(source, "test.rb").unwrap();
+        let root = parse_result.node();
+        let program = root.as_program_node().unwrap();
+
+        let mut genv = GlobalEnv::new();
+        let mut lenv = LocalEnv::new();
+        let mut changes = ChangeSet::new();
+
+        for stmt in &program.statements().body() {
+            crate::analyzer::install::install_node(&mut genv, &mut lenv, &mut changes, source, &stmt);
+        }
+
+        // Method should be registered with qualified name "Api::V1::User"
+        let info = genv
+            .resolve_method(&Type::instance("Api::V1::User"), "name")
+            .expect("Api::V1::User#name should be registered");
+        assert!(info.return_vertex.is_some());
+
+        // Should NOT be registered with simple name "User"
+        assert!(
+            genv.resolve_method(&Type::instance("User"), "name").is_none(),
+            "User#name should not exist — method should be registered under qualified name"
+        );
+    }
+
+    #[test]
+    fn test_same_class_name_different_namespace() {
+        let source = r#"
+module Api
+  class User
+    def name
+      "api_user"
+    end
+  end
+end
+
+module Admin
+  class User
+    def name
+      "admin_user"
+    end
+  end
+end
+"#;
+        let session = ParseSession::new();
+        let parse_result = session.parse_source(source, "test.rb").unwrap();
+        let root = parse_result.node();
+        let program = root.as_program_node().unwrap();
+
+        let mut genv = GlobalEnv::new();
+        let mut lenv = LocalEnv::new();
+        let mut changes = ChangeSet::new();
+
+        for stmt in &program.statements().body() {
+            crate::analyzer::install::install_node(&mut genv, &mut lenv, &mut changes, source, &stmt);
+        }
+
+        // Both should be registered separately
+        let api_info = genv
+            .resolve_method(&Type::instance("Api::User"), "name")
+            .expect("Api::User#name should be registered");
+        assert!(api_info.return_vertex.is_some());
+
+        let admin_info = genv
+            .resolve_method(&Type::instance("Admin::User"), "name")
+            .expect("Admin::User#name should be registered");
+        assert!(admin_info.return_vertex.is_some());
+
+        // Simple "User" should not resolve
+        assert!(
+            genv.resolve_method(&Type::instance("User"), "name").is_none(),
+            "User#name should not exist — both are under qualified names"
+        );
     }
 }

--- a/rust/src/analyzer/dispatch.rs
+++ b/rust/src/analyzer/dispatch.rs
@@ -241,12 +241,8 @@ pub(crate) fn process_needs_child(
             block,
             arguments,
         } => {
-            // Use the same naming as method registration in definitions.rs
-            let recv_type_name = genv
-                .scope_manager
-                .current_class_name()
-                .or_else(|| genv.scope_manager.current_module_name());
-            let recv_vtx = if let Some(name) = recv_type_name {
+            // Use qualified name to match method registration in definitions.rs
+            let recv_vtx = if let Some(name) = genv.scope_manager.current_qualified_name() {
                 genv.new_source(Type::instance(&name))
             } else {
                 genv.new_source(Type::instance("Object"))
@@ -439,10 +435,10 @@ end
 "#;
         let genv = analyze(source);
 
-        // Method registered with simple class name "User" (current behavior of definitions.rs)
+        // Method registered with qualified name "Api::V1::User"
         let info = genv
-            .resolve_method(&Type::instance("User"), "greet")
-            .expect("User#greet should be registered");
+            .resolve_method(&Type::instance("Api::V1::User"), "greet")
+            .expect("Api::V1::User#greet should be registered");
         assert!(info.return_vertex.is_some());
 
         let ret_vtx = info.return_vertex.unwrap();
@@ -685,10 +681,10 @@ end
 "#;
         let genv = analyze(source);
 
-        // Registered with simple class name "User"
+        // Registered with qualified name "Api::User"
         let info = genv
-            .resolve_method(&Type::instance("User"), "name")
-            .expect("User#name should be registered");
+            .resolve_method(&Type::instance("Api::User"), "name")
+            .expect("Api::User#name should be registered");
         assert!(info.return_vertex.is_some());
         assert_eq!(get_type_show(&genv, info.return_vertex.unwrap()), "String");
     }
@@ -871,6 +867,29 @@ User.some_method
         assert!(
             genv.type_errors.is_empty(),
             "User.some_method should not produce type errors (Singleton suppression): {:?}",
+            genv.type_errors
+        );
+    }
+
+    // Test: ConstantPathNode.new resolves with qualified method name
+    #[test]
+    fn test_constant_path_new_with_qualified_method() {
+        let source = r#"
+module Api
+  class User
+    def name
+      "Alice"
+    end
+  end
+end
+
+Api::User.new.name
+"#;
+        let genv = analyze(source);
+        // Api::User.new.name should resolve correctly — no type errors
+        assert!(
+            genv.type_errors.is_empty(),
+            "Api::User.new.name should not produce type errors: {:?}",
             genv.type_errors
         );
     }

--- a/rust/src/env/global_env.rs
+++ b/rust/src/env/global_env.rs
@@ -209,10 +209,7 @@ impl GlobalEnv {
     /// Enter a method scope
     pub fn enter_method(&mut self, name: String) -> ScopeId {
         // Look for class or module context
-        let receiver_type = self
-            .scope_manager
-            .current_class_name()
-            .or_else(|| self.scope_manager.current_module_name());
+        let receiver_type = self.scope_manager.current_qualified_name();
         let scope_id = self.scope_manager.new_scope(ScopeKind::Method {
             name,
             receiver_type,

--- a/test/constant_read_test.rb
+++ b/test/constant_read_test.rb
@@ -73,6 +73,50 @@ class ConstantReadTest < Minitest::Test
   end
 
   # ============================================
+  # Qualified name (ConstantPathNode)
+  # ============================================
+
+  def test_qualified_constant_path_new_method_call
+    source = <<~RUBY
+      module Api
+        class User
+          def name
+            "Alice"
+          end
+        end
+      end
+
+      Api::User.new.name.upcase
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_same_class_name_different_namespace
+    source = <<~RUBY
+      module Api
+        class User
+          def name
+            "api_user"
+          end
+        end
+      end
+
+      module Admin
+        class User
+          def role
+            "admin"
+          end
+        end
+      end
+
+      Api::User.new.name.upcase
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  # ============================================
   # Error Detection
   # ============================================
 
@@ -104,5 +148,21 @@ class ConstantReadTest < Minitest::Test
     RUBY
 
     assert_check_error(source, method_name: 'upcase', receiver_type: 'Integer')
+  end
+
+  def test_qualified_constant_path_new_type_error
+    source = <<~RUBY
+      module Api
+        class User
+          def name
+            "Alice"
+          end
+        end
+      end
+
+      Api::User.new.name.even?
+    RUBY
+
+    assert_check_error(source, method_name: 'even?', receiver_type: 'String')
   end
 end


### PR DESCRIPTION
Methods in nested modules/classes (e.g., Api::User#name) were registered with simple class names, causing same-named classes in different namespaces to overwrite each other. Now uses current_qualified_name() so that Api::User#name and Admin::User#name are registered separately.