### PR TITLE
Release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2026-02-23
+
+### Added
+
+- String interpolation type inference (`InterpolatedStringNode`, `InterpolatedSymbolNode`, `InterpolatedRegularExpressionNode`) ([#26](https://github.com/dak2/method-ray/pull/26))
+- Parentheses node type inference for parenthesized expressions ([#27](https://github.com/dak2/method-ray/pull/27))
+- Qualified name method registration to resolve namespace conflicts ([#28](https://github.com/dak2/method-ray/pull/28))
+- Return statement type inference with merge vertex pattern ([#29](https://github.com/dak2/method-ray/pull/29))
+- Ternary operator type inference tests ([#30](https://github.com/dak2/method-ray/pull/30))
+- Logical operator (`&&`/`||`) type inference with union type approximation ([#31](https://github.com/dak2/method-ray/pull/31))
+- Class method (`def self.foo`) type registration and checking ([#32](https://github.com/dak2/method-ray/pull/32))
+
+### Changed
+
+- Removed stateless `Analyzer` class and simplified Ruby FFI surface to module functions ([#33](https://github.com/dak2/method-ray/pull/33))
+
+### Deprecated
+
+- `clear_cache` command ([#25](https://github.com/dak2/method-ray/pull/25))
+
 ## [0.1.4] - 2026-02-16
 
 ### Added
@@ -69,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 - `methodray check` - Static type checking for Ruby files
 
+[0.1.5]: https://github.com/dak2/method-ray/releases/tag/v0.1.5
 [0.1.4]: https://github.com/dak2/method-ray/releases/tag/v0.1.4
 [0.1.3]: https://github.com/dak2/method-ray/releases/tag/v0.1.3
 [0.1.2]: https://github.com/dak2/method-ray/releases/tag/v0.1.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    method-ray (0.1.4)
+    method-ray (0.1.5)
       rbs (~> 3.0)
 
 GEM
@@ -66,7 +66,7 @@ CHECKSUMS
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  method-ray (0.1.4)
+  method-ray (0.1.5)
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.1) sha256=06f6a725d2cd91e5e7f2b7c32ba143631e1f7c8ae2fb918fc4cebec187e6a688

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methodray"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 
 [lib]

--- a/lib/methodray/version.rb
+++ b/lib/methodray/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MethodRay
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methodray-core"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
### Added

- String interpolation type inference (`InterpolatedStringNode`, `InterpolatedSymbolNode`, `InterpolatedRegularExpressionNode`) ([#26](https://github.com/dak2/method-ray/pull/26))
- Parentheses node type inference for parenthesized expressions ([#27](https://github.com/dak2/method-ray/pull/27))
- Qualified name method registration to resolve namespace conflicts ([#28](https://github.com/dak2/method-ray/pull/28))
- Return statement type inference with merge vertex pattern ([#29](https://github.com/dak2/method-ray/pull/29))
- Ternary operator type inference tests ([#30](https://github.com/dak2/method-ray/pull/30))
- Logical operator (`&&`/`||`) type inference with union type approximation ([#31](https://github.com/dak2/method-ray/pull/31))
- Class method (`def self.foo`) type registration and checking ([#32](https://github.com/dak2/method-ray/pull/32))

### Changed

- Removed stateless `Analyzer` class and simplified Ruby FFI surface to module functions ([#33](https://github.com/dak2/method-ray/pull/33))

### Deprecated

- `clear_cache` command ([#25](https://github.com/dak2/method-ray/pull/25))