### PR TITLE
Embed method_loader at compile time

### DIFF
--- a/rust/src/rbs/loader.rs
+++ b/rust/src/rbs/loader.rs
@@ -37,12 +37,11 @@ impl<'a> RbsLoader<'a> {
 
     /// Load all method definitions from RBS
     pub fn load_methods(&self) -> Result<Vec<RbsMethodInfo>, RbsError> {
-        // Load method_loader.rb
-        let rb_path = concat!(env!("CARGO_MANIFEST_DIR"), "/src/rbs/method_loader.rb");
-        let load_code = format!("require '{}'", rb_path);
+        // Load method_loader.rb (embedded at compile time to avoid hardcoded paths)
+        let ruby_code = include_str!("method_loader.rb");
         let _: Value = self
             .ruby
-            .eval(&load_code)
+            .eval(ruby_code)
             .map_err(|e| RbsError::LoadError(format!("Failed to load method_loader.rb: {}", e)))?;
 
         // Instantiate Rbs::MethodLoader class and call method

--- a/rust/src/rbs/method_loader.rb
+++ b/rust/src/rbs/method_loader.rb
@@ -4,6 +4,8 @@ require 'rbs'
 
 # TODO: use ruby-rbs crate when available
 # https://github.com/ruby/rbs/pull/2808
+return if defined?(Rbs::MethodLoader)
+
 module Rbs
   class MethodLoader
     TARGET_CLASSES = %w[

--- a/rust/src/rbs/mod.rs
+++ b/rust/src/rbs/mod.rs
@@ -14,3 +14,32 @@ pub mod loader;
 pub use error::RbsError;
 #[cfg(feature = "ruby-ffi")]
 pub use loader::{register_rbs_methods, RbsLoader, RbsMethodInfo};
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_embedded_method_loader_contains_expected_class() {
+        let ruby_code = include_str!("method_loader.rb");
+        assert!(
+            ruby_code.contains("class MethodLoader"),
+            "Embedded Ruby code should contain MethodLoader class definition"
+        );
+        assert!(
+            ruby_code.contains("def load_methods"),
+            "Embedded Ruby code should contain load_methods method"
+        );
+    }
+
+    #[test]
+    fn test_embedded_method_loader_has_no_absolute_paths() {
+        let ruby_code = include_str!("method_loader.rb");
+        let forbidden_patterns = ["/home/runner/", "/Users/", "/tmp/build/"];
+        for pattern in &forbidden_patterns {
+            assert!(
+                !ruby_code.contains(pattern),
+                "Embedded Ruby code should not contain absolute path: {}",
+                pattern
+            );
+        }
+    }
+}


### PR DESCRIPTION
Replace runtime require via CARGO_MANIFEST_DIR with include_str! to eliminate dependency on source directory at runtime. Add eval guard to prevent repeated class redefinition.