### PR TITLE
Release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2026-02-23
+
+### Fixed
+
+- Embed `method_loader.rb` at compile time with `include_str!` to eliminate runtime dependency on source directory ([#35](https://github.com/dak2/method-ray/pull/35))
+
 ## [0.1.5] - 2026-02-23
 
 ### Added
@@ -89,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 - `methodray check` - Static type checking for Ruby files
 
+[0.1.6]: https://github.com/dak2/method-ray/releases/tag/v0.1.6
 [0.1.5]: https://github.com/dak2/method-ray/releases/tag/v0.1.5
 [0.1.4]: https://github.com/dak2/method-ray/releases/tag/v0.1.4
 [0.1.3]: https://github.com/dak2/method-ray/releases/tag/v0.1.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    method-ray (0.1.5)
+    method-ray (0.1.6)
       rbs (~> 3.0)
 
 GEM
@@ -66,7 +66,7 @@ CHECKSUMS
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  method-ray (0.1.5)
+  method-ray (0.1.6)
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.1) sha256=06f6a725d2cd91e5e7f2b7c32ba143631e1f7c8ae2fb918fc4cebec187e6a688

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methodray"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 
 [lib]

--- a/lib/methodray/version.rb
+++ b/lib/methodray/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MethodRay
-  VERSION = '0.1.5'
+  VERSION = '0.1.6'
 end

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methodray-core"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## Summary
- Bump version to 0.1.6
- Update CHANGELOG.md with v0.1.6 entry

## Changes since v0.1.5
- Embed `method_loader.rb` at compile time with `include_str!` to eliminate runtime dependency on source directory (#35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)