### PR TITLE
Extract bytes_to_name helper to UTF-8 conversion

### DIFF
--- a/rust/src/analyzer/blocks.rs
+++ b/rust/src/analyzer/blocks.rs
@@ -8,6 +8,7 @@
 use crate::env::{GlobalEnv, LocalEnv, ScopeKind};
 use crate::graph::{ChangeSet, VertexId};
 
+use super::bytes_to_name;
 use super::parameters::{install_optional_parameter, install_required_parameter, install_rest_parameter};
 
 /// Process block node
@@ -68,7 +69,7 @@ fn install_block_parameters_with_vtxs(
         // Required parameters (most common in blocks)
         for node in params.requireds().iter() {
             if let Some(req_param) = node.as_required_parameter_node() {
-                let name = String::from_utf8_lossy(req_param.name().as_slice()).to_string();
+                let name = bytes_to_name(req_param.name().as_slice());
                 let vtx = install_block_parameter(genv, lenv, name);
                 vtxs.push(vtx);
             }
@@ -77,7 +78,7 @@ fn install_block_parameters_with_vtxs(
         // Optional parameters: { |x = 1| ... }
         for node in params.optionals().iter() {
             if let Some(opt_param) = node.as_optional_parameter_node() {
-                let name = String::from_utf8_lossy(opt_param.name().as_slice()).to_string();
+                let name = bytes_to_name(opt_param.name().as_slice());
                 let default_value = opt_param.value();
 
                 if let Some(default_vtx) =
@@ -97,7 +98,7 @@ fn install_block_parameters_with_vtxs(
         if let Some(rest_node) = params.rest() {
             if let Some(rest_param) = rest_node.as_rest_parameter_node() {
                 if let Some(name_id) = rest_param.name() {
-                    let name = String::from_utf8_lossy(name_id.as_slice()).to_string();
+                    let name = bytes_to_name(name_id.as_slice());
                     let vtx = install_rest_parameter(genv, lenv, name);
                     vtxs.push(vtx);
                 }

--- a/rust/src/analyzer/definitions.rs
+++ b/rust/src/analyzer/definitions.rs
@@ -11,6 +11,7 @@ use crate::graph::{ChangeSet, VertexId};
 use crate::types::Type;
 use ruby_prism::Node;
 
+use super::bytes_to_name;
 use super::install::install_statements;
 use super::parameters::install_parameters;
 
@@ -64,7 +65,7 @@ pub(crate) fn process_def_node(
     source: &str,
     def_node: &ruby_prism::DefNode,
 ) -> Option<VertexId> {
-    let method_name = String::from_utf8_lossy(def_node.name().as_slice()).to_string();
+    let method_name = bytes_to_name(def_node.name().as_slice());
 
     // Check if this is a class method (def self.foo)
     let is_class_method = def_node
@@ -163,7 +164,7 @@ fn extract_module_name(module_node: &ruby_prism::ModuleNode) -> String {
 pub(crate) fn extract_constant_path(node: &Node) -> Option<String> {
     // Simple constant read: `User`
     if let Some(constant_read) = node.as_constant_read_node() {
-        return Some(String::from_utf8_lossy(constant_read.name().as_slice()).to_string());
+        return Some(bytes_to_name(constant_read.name().as_slice()));
     }
 
     // Constant path: `Api::User` or `Api::V1::User`
@@ -171,7 +172,7 @@ pub(crate) fn extract_constant_path(node: &Node) -> Option<String> {
         // name() returns Option<ConstantId>, use as_slice() to get &[u8]
         let name = constant_path
             .name()
-            .map(|id| String::from_utf8_lossy(id.as_slice()).to_string())?;
+            .map(|id| bytes_to_name(id.as_slice()))?;
 
         // Get parent path if exists
         if let Some(parent_node) = constant_path.parent() {

--- a/rust/src/analyzer/dispatch.rs
+++ b/rust/src/analyzer/dispatch.rs
@@ -9,6 +9,7 @@ use crate::source_map::SourceLocation;
 use crate::types::Type;
 use ruby_prism::Node;
 
+use super::bytes_to_name;
 use super::calls::install_method_call;
 use super::variables::{
     install_ivar_read, install_ivar_write, install_local_var_read, install_local_var_write,
@@ -68,7 +69,7 @@ pub enum NeedsChildKind<'a> {
 pub fn dispatch_simple(genv: &mut GlobalEnv, lenv: &mut LocalEnv, node: &Node) -> DispatchResult {
     // Instance variable read: @name
     if let Some(ivar_read) = node.as_instance_variable_read_node() {
-        let ivar_name = String::from_utf8_lossy(ivar_read.name().as_slice()).to_string();
+        let ivar_name = bytes_to_name(ivar_read.name().as_slice());
         return match install_ivar_read(genv, &ivar_name) {
             Some(vtx) => DispatchResult::Vertex(vtx),
             None => DispatchResult::NotHandled,
@@ -82,7 +83,7 @@ pub fn dispatch_simple(genv: &mut GlobalEnv, lenv: &mut LocalEnv, node: &Node) -
 
     // Local variable read: x
     if let Some(read_node) = node.as_local_variable_read_node() {
-        let var_name = String::from_utf8_lossy(read_node.name().as_slice()).to_string();
+        let var_name = bytes_to_name(read_node.name().as_slice());
         return match install_local_var_read(lenv, &var_name) {
             Some(vtx) => DispatchResult::Vertex(vtx),
             None => DispatchResult::NotHandled,
@@ -91,7 +92,7 @@ pub fn dispatch_simple(genv: &mut GlobalEnv, lenv: &mut LocalEnv, node: &Node) -
 
     // ConstantReadNode: User → Type::Singleton("User") or Type::Singleton("Api::User")
     if let Some(const_read) = node.as_constant_read_node() {
-        let name = String::from_utf8_lossy(const_read.name().as_slice()).to_string();
+        let name = bytes_to_name(const_read.name().as_slice());
         let resolved_name = genv.scope_manager.lookup_constant(&name)
             .unwrap_or(name);
         let vtx = genv.new_source(Type::singleton(&resolved_name));
@@ -118,7 +119,7 @@ fn extract_symbol_names(call_node: &ruby_prism::CallNode) -> Vec<String> {
                 .iter()
                 .filter_map(|arg| {
                     arg.as_symbol_node().map(|sym| {
-                        String::from_utf8_lossy(&sym.unescaped()).to_string()
+                        bytes_to_name(sym.unescaped())
                     })
                 })
                 .collect()
@@ -130,7 +131,7 @@ fn extract_symbol_names(call_node: &ruby_prism::CallNode) -> Vec<String> {
 pub fn dispatch_needs_child<'a>(node: &Node<'a>, source: &str) -> Option<NeedsChildKind<'a>> {
     // Instance variable write: @name = value
     if let Some(ivar_write) = node.as_instance_variable_write_node() {
-        let ivar_name = String::from_utf8_lossy(ivar_write.name().as_slice()).to_string();
+        let ivar_name = bytes_to_name(ivar_write.name().as_slice());
         return Some(NeedsChildKind::IvarWrite {
             ivar_name,
             value: ivar_write.value(),
@@ -139,7 +140,7 @@ pub fn dispatch_needs_child<'a>(node: &Node<'a>, source: &str) -> Option<NeedsCh
 
     // Local variable write: x = value
     if let Some(write_node) = node.as_local_variable_write_node() {
-        let var_name = String::from_utf8_lossy(write_node.name().as_slice()).to_string();
+        let var_name = bytes_to_name(write_node.name().as_slice());
         return Some(NeedsChildKind::LocalVarWrite {
             var_name,
             value: write_node.value(),
@@ -148,7 +149,7 @@ pub fn dispatch_needs_child<'a>(node: &Node<'a>, source: &str) -> Option<NeedsCh
 
     // Method call: x.upcase, x.each { |i| ... }, or name (implicit self)
     if let Some(call_node) = node.as_call_node() {
-        let method_name = String::from_utf8_lossy(call_node.name().as_slice()).to_string();
+        let method_name = bytes_to_name(call_node.name().as_slice());
         let block = call_node.block();
         let arguments: Vec<Node<'a>> = call_node
             .arguments()

--- a/rust/src/analyzer/mod.rs
+++ b/rust/src/analyzer/mod.rs
@@ -13,3 +13,32 @@ mod returns;
 mod variables;
 
 pub use install::AstInstaller;
+
+/// Convert ruby-prism identifier bytes to a String (lossy).
+///
+/// ruby-prism returns identifiers (method names, variable names, constant names,
+/// parameter names) as `&[u8]`. This helper provides a single conversion point
+/// used throughout the analyzer.
+///
+/// Note: Uses `from_utf8_lossy` — invalid UTF-8 bytes are replaced with U+FFFD.
+/// ruby-prism identifiers are expected to be valid UTF-8, so this should not
+/// occur in practice. Do NOT use this function for arbitrary byte data such as
+/// string literal contents.
+pub(crate) fn bytes_to_name(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bytes_to_name;
+
+    #[test]
+    fn test_bytes_to_name_valid_utf8() {
+        assert_eq!(bytes_to_name(b"hello"), "hello");
+    }
+
+    #[test]
+    fn test_bytes_to_name_invalid_utf8_replaced() {
+        assert_eq!(bytes_to_name(b"hello\xff"), "hello\u{FFFD}");
+    }
+}

--- a/rust/src/analyzer/parameters.rs
+++ b/rust/src/analyzer/parameters.rs
@@ -9,6 +9,8 @@ use crate::env::{GlobalEnv, LocalEnv};
 use crate::graph::{ChangeSet, VertexId};
 use crate::types::Type;
 
+use super::bytes_to_name;
+
 /// Install a required parameter as a local variable
 ///
 /// Required parameters start with Bot (untyped) type since we don't know
@@ -129,7 +131,7 @@ pub(crate) fn install_parameters(
     // Required parameters: def foo(a, b)
     for node in params_node.requireds().iter() {
         if let Some(req_param) = node.as_required_parameter_node() {
-            let name = String::from_utf8_lossy(req_param.name().as_slice()).to_string();
+            let name = bytes_to_name(req_param.name().as_slice());
             let vtx = install_required_parameter(genv, lenv, name);
             param_vtxs.push(vtx);
         }
@@ -138,7 +140,7 @@ pub(crate) fn install_parameters(
     // Optional parameters: def foo(a = 1, b = "hello")
     for node in params_node.optionals().iter() {
         if let Some(opt_param) = node.as_optional_parameter_node() {
-            let name = String::from_utf8_lossy(opt_param.name().as_slice()).to_string();
+            let name = bytes_to_name(opt_param.name().as_slice());
             let default_value = opt_param.value();
 
             let vtx = if let Some(default_vtx) =
@@ -157,7 +159,7 @@ pub(crate) fn install_parameters(
     if let Some(rest_node) = params_node.rest() {
         if let Some(rest_param) = rest_node.as_rest_parameter_node() {
             if let Some(name_id) = rest_param.name() {
-                let name = String::from_utf8_lossy(name_id.as_slice()).to_string();
+                let name = bytes_to_name(name_id.as_slice());
                 install_rest_parameter(genv, lenv, name);
             }
         }
@@ -168,7 +170,7 @@ pub(crate) fn install_parameters(
     if let Some(kwrest_node) = params_node.keyword_rest() {
         if let Some(kwrest_param) = kwrest_node.as_keyword_rest_parameter_node() {
             if let Some(name_id) = kwrest_param.name() {
-                let name = String::from_utf8_lossy(name_id.as_slice()).to_string();
+                let name = bytes_to_name(name_id.as_slice());
                 install_keyword_rest_parameter(genv, lenv, name);
             }
         }


### PR DESCRIPTION
The pattern `String::from_utf8_lossy(x.as_slice()).to_string()` was duplicated 17 times across 4 files under analyzer/. Centralizing the conversion into a single helper makes future policy changes (e.g. switching from lossy to strict) a one-line fix.