### PR TITLE
Add while/until loop support to type inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ vendor/
 tmp/
 
 # Claude 
-.claude/Claude.local*.md
+.claude/locals/*

--- a/rust/src/analyzer/install.rs
+++ b/rust/src/analyzer/install.rs
@@ -13,8 +13,9 @@ use super::conditionals::{process_case_node, process_if_node, process_unless_nod
 use super::definitions::{process_class_node, process_def_node, process_module_node};
 use super::dispatch::{dispatch_needs_child, dispatch_simple, process_needs_child, DispatchResult};
 use super::literals::install_literal_node;
-use super::parentheses::process_parentheses_node;
+use super::loops::{process_until_node, process_while_node};
 use super::operators::{process_and_node, process_or_node};
+use super::parentheses::process_parentheses_node;
 use super::returns::process_return_node;
 
 /// Build graph from AST (public API wrapper)
@@ -77,6 +78,13 @@ pub(crate) fn install_node(
     }
     if let Some(case_node) = node.as_case_node() {
         return process_case_node(genv, lenv, changes, source, &case_node);
+    }
+
+    if let Some(while_node) = node.as_while_node() {
+        return process_while_node(genv, lenv, changes, source, &while_node);
+    }
+    if let Some(until_node) = node.as_until_node() {
+        return process_until_node(genv, lenv, changes, source, &until_node);
     }
 
     if let Some(paren_node) = node.as_parentheses_node() {

--- a/rust/src/analyzer/loops.rs
+++ b/rust/src/analyzer/loops.rs
@@ -1,0 +1,176 @@
+//! Loops - while/until loop type inference
+//!
+//! Ruby loop expressions evaluate to nil (except when break passes a value).
+//! Break value propagation is not yet supported.
+
+use crate::env::{GlobalEnv, LocalEnv};
+use crate::graph::{ChangeSet, VertexId};
+use crate::types::Type;
+use ruby_prism::{UntilNode, WhileNode};
+
+use super::install::{install_node, install_statements};
+
+/// Process WhileNode: `while predicate; statements; end`
+///
+/// Returns nil. Traverses predicate and body to register method calls
+/// and variable assignments in the type graph.
+pub(crate) fn process_while_node(
+    genv: &mut GlobalEnv,
+    lenv: &mut LocalEnv,
+    changes: &mut ChangeSet,
+    source: &str,
+    while_node: &WhileNode,
+) -> Option<VertexId> {
+    install_node(genv, lenv, changes, source, &while_node.predicate());
+
+    if let Some(stmts) = while_node.statements() {
+        install_statements(genv, lenv, changes, source, &stmts);
+    }
+
+    Some(genv.new_source(Type::Nil))
+}
+
+/// Process UntilNode: `until predicate; statements; end`
+///
+/// Returns nil. Traverses predicate and body to register method calls
+/// and variable assignments in the type graph.
+pub(crate) fn process_until_node(
+    genv: &mut GlobalEnv,
+    lenv: &mut LocalEnv,
+    changes: &mut ChangeSet,
+    source: &str,
+    until_node: &UntilNode,
+) -> Option<VertexId> {
+    install_node(genv, lenv, changes, source, &until_node.predicate());
+
+    if let Some(stmts) = until_node.statements() {
+        install_statements(genv, lenv, changes, source, &stmts);
+    }
+
+    Some(genv.new_source(Type::Nil))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::analyzer::install::AstInstaller;
+    use crate::env::{GlobalEnv, LocalEnv};
+    use crate::graph::VertexId;
+    use crate::parser::ParseSession;
+    use crate::types::Type;
+
+    /// Helper: parse Ruby source, process with AstInstaller, and return GlobalEnv
+    fn analyze(source: &str) -> GlobalEnv {
+        let session = ParseSession::new();
+        let parse_result = session.parse_source(source, "test.rb").unwrap();
+        let root = parse_result.node();
+        let program = root.as_program_node().unwrap();
+
+        let mut genv = GlobalEnv::new();
+        let mut lenv = LocalEnv::new();
+
+        let mut installer = AstInstaller::new(&mut genv, &mut lenv, source);
+        for stmt in &program.statements().body() {
+            installer.install_node(&stmt);
+        }
+        installer.finish();
+
+        genv
+    }
+
+    /// Helper: get the type string for a vertex ID (checks both Vertex and Source)
+    fn get_type_show(genv: &GlobalEnv, vtx: VertexId) -> String {
+        if let Some(vertex) = genv.get_vertex(vtx) {
+            vertex.show()
+        } else if let Some(source) = genv.get_source(vtx) {
+            source.ty.show()
+        } else {
+            panic!("vertex {:?} not found as either Vertex or Source", vtx);
+        }
+    }
+
+    #[test]
+    fn test_while_returns_nil() {
+        let source = r#"
+class Foo
+  def bar
+    while true
+      "hello"
+    end
+  end
+end
+"#;
+        let genv = analyze(source);
+        let info = genv
+            .resolve_method(&Type::instance("Foo"), "bar")
+            .expect("Foo#bar should be registered");
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "nil");
+    }
+
+    #[test]
+    fn test_until_returns_nil() {
+        let source = r#"
+class Foo
+  def bar
+    until false
+      "hello"
+    end
+  end
+end
+"#;
+        let genv = analyze(source);
+        let info = genv
+            .resolve_method(&Type::instance("Foo"), "bar")
+            .expect("Foo#bar should be registered");
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "nil");
+    }
+
+    #[test]
+    fn test_while_variable_assignment_in_body() {
+        // Should not panic — variable assignment inside loop is processed
+        let source = r#"
+x = "initial"
+while true
+  x = "hello"
+end
+"#;
+        analyze(source);
+    }
+
+    #[test]
+    fn test_while_modifier_form() {
+        let source = r#"
+class Foo
+  def bar
+    x = "hello" while false
+  end
+end
+"#;
+        let genv = analyze(source);
+        let info = genv
+            .resolve_method(&Type::instance("Foo"), "bar")
+            .expect("Foo#bar should be registered");
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "nil");
+    }
+
+    #[test]
+    fn test_begin_end_while() {
+        let source = r#"
+class Foo
+  def bar
+    begin
+      "hello"
+    end while false
+  end
+end
+"#;
+        let genv = analyze(source);
+        let info = genv
+            .resolve_method(&Type::instance("Foo"), "bar")
+            .expect("Foo#bar should be registered");
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "nil");
+    }
+}

--- a/rust/src/analyzer/mod.rs
+++ b/rust/src/analyzer/mod.rs
@@ -6,6 +6,7 @@ mod definitions;
 mod dispatch;
 mod install;
 mod literals;
+mod loops;
 mod operators;
 mod parameters;
 mod parentheses;

--- a/test/loop_test.rb
+++ b/test/loop_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class LoopTest < Minitest::Test
+  include CLITestHelper
+
+  # ============================================
+  # No Error (check CLI)
+  # ============================================
+
+  def test_while_loop_no_false_positive
+    source = <<~RUBY
+      class Foo
+        def bar
+          while true
+            "hello".upcase
+          end
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_until_loop_no_false_positive
+    source = <<~RUBY
+      class Foo
+        def bar
+          until false
+            "hello".upcase
+          end
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  # ============================================
+  # Error Detection (check CLI)
+  # ============================================
+
+  def test_while_loop_detects_type_error
+    source = <<~RUBY
+      class Foo
+        def bar
+          42
+        end
+
+        def baz
+          while true
+            self.bar.upcase
+          end
+        end
+      end
+    RUBY
+
+    assert_check_error(source, method_name: 'upcase', receiver_type: 'Integer')
+  end
+
+  def test_until_loop_detects_type_error
+    source = <<~RUBY
+      class Foo
+        def bar
+          42
+        end
+
+        def baz
+          until false
+            self.bar.upcase
+          end
+        end
+      end
+    RUBY
+
+    assert_check_error(source, method_name: 'upcase', receiver_type: 'Integer')
+  end
+end


### PR DESCRIPTION
## Summary

- Add `loops.rs` module to handle `WhileNode` and `UntilNode` AST nodes in the type inference pipeline
- Traverse loop predicates and bodies to detect type errors within loops (method calls, variable assignments)
- Correctly infer loop expression type as `nil` (matching Ruby semantics)
- Add dispatch entries in `install.rs` for while/until nodes
- Add Ruby integration tests for loop type checking

## Why

Previously, `while` and `until` loops were unhandled AST nodes. The type checker silently skipped them, meaning any method calls or variable assignments inside loop bodies were invisible to type inference. This could cause false negatives (missed type errors) for code within loops.

## Test plan

- [x] `cd rust && cargo test --lib loops` — 5 Rust unit tests pass (basic while/until, modifier form, begin-end-while, variable assignment in body)
- [x] `bundle exec ruby -Ilib -Itest test/loop_test.rb` — Ruby integration tests
- [x] `cd rust && cargo clippy --lib --all-features -- -W clippy::all` — No lint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)