### PR TITLE
Resolve all Clippy warnings for idiomatic Rust

### DIFF
--- a/rust/src/analyzer/dispatch.rs
+++ b/rust/src/analyzer/dispatch.rs
@@ -237,7 +237,8 @@ pub(crate) fn process_needs_child(
         } => {
             let recv_vtx = super::install::install_node(genv, lenv, changes, source, &receiver)?;
             process_method_call_common(
-                genv, lenv, changes, source, recv_vtx, method_name, location, block, arguments,
+                genv, lenv, changes, source,
+                MethodCallContext { recv_vtx, method_name, location, block, arguments },
             )
         }
         NeedsChildKind::ImplicitSelfCall {
@@ -253,7 +254,8 @@ pub(crate) fn process_needs_child(
                 genv.new_source(Type::instance("Object"))
             };
             process_method_call_common(
-                genv, lenv, changes, source, recv_vtx, method_name, location, block, arguments,
+                genv, lenv, changes, source,
+                MethodCallContext { recv_vtx, method_name, location, block, arguments },
             )
         }
         NeedsChildKind::AttrDeclaration { kind, attr_names } => {
@@ -279,6 +281,15 @@ fn finish_local_var_write(
     install_local_var_write(genv, lenv, changes, var_name, value_vtx)
 }
 
+/// Bundled parameters for method call processing
+struct MethodCallContext<'a> {
+    recv_vtx: VertexId,
+    method_name: String,
+    location: SourceLocation,
+    block: Option<Node<'a>>,
+    arguments: Vec<Node<'a>>,
+}
+
 /// MethodCall / ImplicitSelfCall common processing:
 /// Handles argument processing, block processing, and MethodCallBox creation after recv_vtx is obtained
 fn process_method_call_common<'a>(
@@ -286,12 +297,15 @@ fn process_method_call_common<'a>(
     lenv: &mut LocalEnv,
     changes: &mut ChangeSet,
     source: &str,
-    recv_vtx: VertexId,
-    method_name: String,
-    location: SourceLocation,
-    block: Option<Node<'a>>,
-    arguments: Vec<Node<'a>>,
+    ctx: MethodCallContext<'a>,
 ) -> Option<VertexId> {
+    let MethodCallContext {
+        recv_vtx,
+        method_name,
+        location,
+        block,
+        arguments,
+    } = ctx;
     if method_name == "!" {
         return Some(super::operators::process_not_operator(genv));
     }

--- a/rust/src/cache/rbs_cache.rs
+++ b/rust/src/cache/rbs_cache.rs
@@ -37,7 +37,6 @@ impl SerializableMethodInfo {
     }
 }
 
-#[allow(dead_code)]
 impl RbsCache {
     /// Get user cache file path (in ~/.cache/methodray/)
     pub fn cache_path() -> Result<PathBuf> {

--- a/rust/src/cli/commands.rs
+++ b/rust/src/cli/commands.rs
@@ -1,7 +1,7 @@
 //! CLI command implementations
 
 use anyhow::Result;
-use std::path::PathBuf;
+use std::path::Path;
 
 use crate::cache::RbsCache;
 use crate::checker::FileChecker;
@@ -9,7 +9,7 @@ use crate::diagnostics;
 
 /// Check a single Ruby file for type errors
 /// Returns Ok(true) if no errors, Ok(false) if errors found
-pub fn check_single_file(file_path: &PathBuf, verbose: bool) -> Result<bool> {
+pub fn check_single_file(file_path: &Path, verbose: bool) -> Result<bool> {
     let checker = FileChecker::new()?;
     let diagnostics = checker.check_file(file_path)?;
 
@@ -38,7 +38,7 @@ pub fn check_project(_verbose: bool) -> Result<()> {
 }
 
 /// Watch a file for changes and re-check on modifications
-pub fn watch_file(file_path: &PathBuf) -> Result<()> {
+pub fn watch_file(file_path: &Path) -> Result<()> {
     use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
     use std::sync::mpsc::channel;
     use std::time::Duration;

--- a/rust/src/diagnostics/diagnostic.rs
+++ b/rust/src/diagnostics/diagnostic.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 /// Diagnostic severity level (LSP compatible)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum DiagnosticLevel {
     Error,
     Warning,
@@ -28,7 +27,6 @@ pub struct Location {
 
 /// Type checking diagnostic
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct Diagnostic {
     pub location: Location,
     pub level: DiagnosticLevel,
@@ -36,7 +34,6 @@ pub struct Diagnostic {
     pub code: Option<String>, // e.g., "E001"
 }
 
-#[allow(dead_code)]
 impl Diagnostic {
     /// Create an error diagnostic
     pub fn error(location: Location, message: String) -> Self {

--- a/rust/src/diagnostics/formatter.rs
+++ b/rust/src/diagnostics/formatter.rs
@@ -8,7 +8,6 @@ use std::path::Path;
 /// ```text
 /// app/models/user.rb:10:5: error: undefined method `upcase` for Integer
 /// ```
-#[allow(dead_code)]
 pub fn format_diagnostics(diagnostics: &[Diagnostic]) -> String {
     diagnostics
         .iter()

--- a/rust/src/env/box_manager.rs
+++ b/rust/src/env/box_manager.rs
@@ -6,7 +6,6 @@ use crate::graph::{BoxId, BoxTrait};
 use std::collections::{HashMap, HashSet, VecDeque};
 
 /// Manages boxes and their execution queue
-#[allow(dead_code)]
 pub struct BoxManager {
     /// All registered boxes
     pub boxes: HashMap<BoxId, Box<dyn BoxTrait>>,
@@ -24,7 +23,6 @@ impl Default for BoxManager {
     }
 }
 
-#[allow(dead_code)]
 impl BoxManager {
     /// Create a new empty box manager
     pub fn new() -> Self {
@@ -37,8 +35,8 @@ impl BoxManager {
     }
 
     /// Get a box by ID
-    pub fn get(&self, id: BoxId) -> Option<&Box<dyn BoxTrait>> {
-        self.boxes.get(&id)
+    pub fn get(&self, id: BoxId) -> Option<&dyn BoxTrait> {
+        self.boxes.get(&id).map(|b| b.as_ref())
     }
 
     /// Remove a box and return it (for temporary mutation)

--- a/rust/src/env/global_env.rs
+++ b/rust/src/env/global_env.rs
@@ -39,7 +39,6 @@ pub struct GlobalEnv {
     pub scope_manager: ScopeManager,
 }
 
-#[allow(dead_code)]
 impl GlobalEnv {
     pub fn new() -> Self {
         Self {

--- a/rust/src/env/local_env.rs
+++ b/rust/src/env/local_env.rs
@@ -6,7 +6,12 @@ pub struct LocalEnv {
     locals: HashMap<String, VertexId>,
 }
 
-#[allow(dead_code)]
+impl Default for LocalEnv {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LocalEnv {
     pub fn new() -> Self {
         Self {
@@ -39,6 +44,12 @@ impl LocalEnv {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_local_env_default() {
+        let lenv = LocalEnv::default();
+        assert_eq!(lenv.get_var("x"), None);
+    }
 
     #[test]
     fn test_local_env() {

--- a/rust/src/env/scope.rs
+++ b/rust/src/env/scope.rs
@@ -7,7 +7,6 @@ pub struct ScopeId(pub usize);
 
 /// Scope kind
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub enum ScopeKind {
     TopLevel,
     Class {
@@ -27,7 +26,6 @@ pub enum ScopeKind {
 
 /// Scope information
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct Scope {
     pub id: ScopeId,
     pub kind: ScopeKind,
@@ -46,7 +44,6 @@ pub struct Scope {
     pub constants: HashMap<String, String>,
 }
 
-#[allow(dead_code)]
 impl Scope {
     pub fn new(id: ScopeId, kind: ScopeKind, parent: Option<ScopeId>) -> Self {
         Self {
@@ -89,7 +86,12 @@ pub struct ScopeManager {
     current_scope: ScopeId,
 }
 
-#[allow(dead_code)]
+impl Default for ScopeManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ScopeManager {
     pub fn new() -> Self {
         let top_level = Scope::new(ScopeId(0), ScopeKind::TopLevel, None);
@@ -277,6 +279,13 @@ impl ScopeManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_scope_manager_default() {
+        let sm = ScopeManager::default();
+        assert_eq!(sm.current_scope().id, ScopeId(0));
+        assert!(matches!(sm.current_scope().kind, ScopeKind::TopLevel));
+    }
 
     #[test]
     fn test_scope_manager_creation() {

--- a/rust/src/env/vertex_manager.rs
+++ b/rust/src/env/vertex_manager.rs
@@ -17,7 +17,6 @@ pub struct VertexManager {
     next_vertex_id: usize,
 }
 
-#[allow(dead_code)]
 impl VertexManager {
     /// Create a new empty vertex manager
     pub fn new() -> Self {

--- a/rust/src/graph/box.rs
+++ b/rust/src/graph/box.rs
@@ -11,7 +11,6 @@ use crate::types::Type;
 pub struct BoxId(pub usize);
 
 /// Box trait: represents constraints such as method calls
-#[allow(dead_code)]
 pub trait BoxTrait: Send + Sync {
     fn id(&self) -> BoxId;
     fn run(&mut self, genv: &mut GlobalEnv, changes: &mut ChangeSet);
@@ -47,7 +46,6 @@ fn propagate_keyword_arguments(
 }
 
 /// Box representing a method call
-#[allow(dead_code)]
 pub struct MethodCallBox {
     id: BoxId,
     recv: VertexId,
@@ -199,7 +197,6 @@ impl BoxTrait for MethodCallBox {
 /// When a method with a block is called (e.g., `str.each_char { |c| ... }`),
 /// this box resolves the block parameter types from the method's RBS definition
 /// and propagates them to the block parameter vertices.
-#[allow(dead_code)]
 pub struct BlockParameterTypeBox {
     id: BoxId,
     /// Receiver vertex of the method call

--- a/rust/src/graph/change_set.rs
+++ b/rust/src/graph/change_set.rs
@@ -10,6 +10,12 @@ pub struct ChangeSet {
     reschedule_boxes: Vec<BoxId>,
 }
 
+impl Default for ChangeSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ChangeSet {
     pub fn new() -> Self {
         Self {
@@ -74,6 +80,14 @@ pub enum EdgeUpdate {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_change_set_default() {
+        let mut cs = ChangeSet::default();
+        cs.add_edge(VertexId(1), VertexId(2));
+        let updates = cs.reinstall();
+        assert_eq!(updates.len(), 1);
+    }
 
     #[test]
     fn test_change_set_add() {

--- a/rust/src/lsp/server.rs
+++ b/rust/src/lsp/server.rs
@@ -132,7 +132,7 @@ pub async fn run_server() {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let (service, socket) = LspService::new(|client| MethodRayServer::new(client));
+    let (service, socket) = LspService::new(MethodRayServer::new);
 
     Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/rust/src/rbs/loader.rs
+++ b/rust/src/rbs/loader.rs
@@ -155,8 +155,7 @@ pub fn register_rbs_methods(genv: &mut GlobalEnv, ruby: &Ruby) -> Result<usize, 
             cache.to_method_infos()
         } else {
             eprintln!("Cache invalid, reloading from RBS...");
-            let methods = load_and_cache_rbs_methods(ruby, methodray_version, &rbs_version)?;
-            methods
+            load_and_cache_rbs_methods(ruby, methodray_version, &rbs_version)?
         }
     } else {
         eprintln!("No cache found, loading from RBS...");

--- a/rust/src/source_map.rs
+++ b/rust/src/source_map.rs
@@ -30,7 +30,6 @@ pub struct SourceLocation {
     pub length: usize,
 }
 
-#[allow(dead_code)]
 impl SourceLocation {
     pub fn new(line: usize, column: usize, length: usize) -> Self {
         Self {

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -125,7 +125,6 @@ impl From<String> for QualifiedName {
 
 /// Type system for graph-based type inference
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[allow(dead_code)]
 pub enum Type {
     /// Instance type: String, Integer, Api::User, etc.
     Instance { name: QualifiedName },


### PR DESCRIPTION
## Summary

- **Phase 1**: Add `Default` trait impls for `ChangeSet`, `LocalEnv`, `ScopeManager`; remove redundant `let` binding in `rbs/loader.rs`
- **Phase 2**: Remove all blanket `#[allow(dead_code)]` annotations across 10 files, confirming all annotated code is actually used
- **Phase 3**: Fix API-level warnings — `&Box<dyn BoxTrait>` → `&dyn BoxTrait` (double indirection), bundle 9-param function into `MethodCallContext` struct (too_many_arguments), replace redundant closure with function pointer, `&PathBuf` → `&Path`

## Test plan

- [x] `cd rust && cargo test --lib` — all existing tests pass
- [x] `cd rust && cargo clippy --lib --all-features -- -W clippy::all` — zero warnings
- [x] New unit tests: `test_local_env_default`, `test_scope_manager_default`, `test_change_set_default`

🤖 Generated with [Claude Code](https://claude.com/claude-code)