### PR TITLE
Release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.8] - 2026-03-09
+
+### Added
+
+- while/until loop support to type inference ([#46](https://github.com/dak2/method-ray/pull/46))
+- Not operator (!) support to type inference ([#47](https://github.com/dak2/method-ray/pull/47))
+- begin/rescue/ensure exception handling support to type inference ([#48](https://github.com/dak2/method-ray/pull/48))
+- Keyword argument support to type inference ([#49](https://github.com/dak2/method-ray/pull/49))
+- Multiple assignment support to type inference ([#50](https://github.com/dak2/method-ray/pull/50))
+
+### Changed
+
+- Resolve all Clippy warnings for cleaner, more idiomatic Rust ([#51](https://github.com/dak2/method-ray/pull/51))
+
 ## [0.1.7] - 2026-03-07
 
 ### Added
@@ -109,6 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 - `methodray check` - Static type checking for Ruby files
 
+[0.1.8]: https://github.com/dak2/method-ray/releases/tag/v0.1.8
 [0.1.7]: https://github.com/dak2/method-ray/releases/tag/v0.1.7
 [0.1.6]: https://github.com/dak2/method-ray/releases/tag/v0.1.6
 [0.1.5]: https://github.com/dak2/method-ray/releases/tag/v0.1.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    method-ray (0.1.7)
+    method-ray (0.1.8)
       rbs (~> 3.0)
 
 GEM
@@ -66,7 +66,7 @@ CHECKSUMS
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  method-ray (0.1.7)
+  method-ray (0.1.8)
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.1) sha256=06f6a725d2cd91e5e7f2b7c32ba143631e1f7c8ae2fb918fc4cebec187e6a688

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methodray"
-version = "0.1.6"
+version = "0.1.8"
 edition = "2021"
 
 [lib]

--- a/lib/methodray/version.rb
+++ b/lib/methodray/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MethodRay
-  VERSION = '0.1.7'
+  VERSION = '0.1.8'
 end

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methodray-core"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## Summary
- Bump version to 0.1.8
- Update CHANGELOG.md with v0.1.8 entry

## Changes since v0.1.7
- while/until loop support to type inference (#46)
- Not operator (!) support to type inference (#47)
- begin/rescue/ensure exception handling support to type inference (#48)
- Keyword argument support to type inference (#49)
- Multiple assignment support to type inference (#50)
- Resolve all Clippy warnings for cleaner, more idiomatic Rust (#51)

🤖 Generated with [Claude Code](https://claude.com/claude-code)