### PR TITLE
Add auto-tagging workflow for release PR merges

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,35 @@
+name: Publish Release Tag on Release PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release-v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract version from branch name
+        id: version
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          VERSION="${BRANCH#release-}"
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version format: $VERSION"
+            exit 1
+          fi
+          echo "tag=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git tag "$TAG"
+          git push origin "$TAG"


### PR DESCRIPTION
## Summary
- Add a workflow that automatically creates and pushes a `vX.Y.Z` tag when a `release-vX.Y.Z` branch is merged into main
- This triggers the existing `release.yml` workflow, eliminating the manual tagging step

## Flow
```
Merge release-vX.Y.Z into main
  → release-tag.yml: auto-create & push vX.Y.Z tag
    → release.yml: build native gems & create GitHub Release
```

## Test plan
- [ ] Verify that merging a branch named `release-v0.1.9` automatically creates the `v0.1.9` tag
- [ ] Verify that invalid branch names (e.g., `release-vinvalid`) fail validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)