### PR TITLE
Infer actual exception types in rescue clauses

### DIFF
--- a/rust/src/analyzer/exceptions.rs
+++ b/rust/src/analyzer/exceptions.rs
@@ -81,6 +81,24 @@ fn process_rescue_chain(
     }
 }
 
+/// Extract the exception type from rescue node's exception class list.
+/// Falls back to StandardError when no exceptions are specified or none can be resolved.
+// TODO: Non-constant exception expressions (method calls, splats, variables) are silently skipped.
+fn extract_exception_type(rescue_node: &RescueNode) -> Type {
+    let types: Vec<Type> = rescue_node
+        .exceptions()
+        .iter()
+        .filter_map(|exc| super::definitions::extract_constant_path(&exc))
+        .map(|name| Type::instance(&name))
+        .collect();
+
+    if types.is_empty() {
+        Type::instance("StandardError")
+    } else {
+        Type::union_of(types)
+    }
+}
+
 /// Process a single RescueNode body.
 /// Registers the rescue variable (=> e), processes the body,
 /// then removes the variable from scope.
@@ -97,14 +115,14 @@ fn process_rescue_body(
 
     // Save/restore rescue variable binding (=> e)
     // TODO: Only LocalVariableTargetNode is handled; instance/global/class vars are not yet supported.
-    // TODO: Always typed as StandardError regardless of declared exception class.
     let var_binding = if let Some(ref_node) = rescue_node.reference() {
         ref_node.as_local_variable_target_node().map(|target| {
             let name = bytes_to_name(target.name().as_slice());
             let saved = lenv.get_var(&name);
             let exception_vtx = genv.new_vertex();
-            let std_err_src = genv.new_source(Type::instance("StandardError"));
-            genv.add_edge(std_err_src, exception_vtx);
+            let exception_type = extract_exception_type(rescue_node);
+            let exception_src = genv.new_source(exception_type);
+            genv.add_edge(exception_src, exception_vtx);
             lenv.new_var(name.clone(), exception_vtx);
             (name, saved)
         })
@@ -493,6 +511,89 @@ end
         assert!(
             type_str.contains("StandardError"),
             "should contain StandardError: {}",
+            type_str
+        );
+    }
+
+    #[test]
+    fn test_rescue_specific_exception_class() {
+        let source = r#"
+class Foo
+  def bar
+    begin
+      "hello"
+    rescue ArgumentError => e
+      e
+    end
+  end
+end
+"#;
+        let genv = analyze(source);
+        let info = genv
+            .resolve_method(&Type::instance("Foo"), "bar")
+            .expect("Foo#bar should be registered");
+        let ret_vtx = info.return_vertex.unwrap();
+        let type_str = get_type_show(&genv, ret_vtx);
+        assert!(
+            type_str.contains("ArgumentError"),
+            "should contain ArgumentError: {}",
+            type_str
+        );
+    }
+
+    #[test]
+    fn test_rescue_multiple_exception_classes() {
+        let source = r#"
+class Foo
+  def bar
+    begin
+      "hello"
+    rescue TypeError, NameError => e
+      e
+    end
+  end
+end
+"#;
+        let genv = analyze(source);
+        let info = genv
+            .resolve_method(&Type::instance("Foo"), "bar")
+            .expect("Foo#bar should be registered");
+        let ret_vtx = info.return_vertex.unwrap();
+        let type_str = get_type_show(&genv, ret_vtx);
+        assert!(
+            type_str.contains("TypeError"),
+            "should contain TypeError: {}",
+            type_str
+        );
+        assert!(
+            type_str.contains("NameError"),
+            "should contain NameError: {}",
+            type_str
+        );
+    }
+
+    #[test]
+    fn test_rescue_qualified_exception_class() {
+        let source = r#"
+class Foo
+  def bar
+    begin
+      "hello"
+    rescue Net::HTTPError => e
+      e
+    end
+  end
+end
+"#;
+        let genv = analyze(source);
+        let info = genv
+            .resolve_method(&Type::instance("Foo"), "bar")
+            .expect("Foo#bar should be registered");
+        let ret_vtx = info.return_vertex.unwrap();
+        let type_str = get_type_show(&genv, ret_vtx);
+        assert!(
+            type_str.contains("Net::HTTPError"),
+            "should contain Net::HTTPError: {}",
             type_str
         );
     }

--- a/rust/src/analyzer/literals.rs
+++ b/rust/src/analyzer/literals.rs
@@ -118,13 +118,9 @@ fn install_array_literal_elements(
 
     let array_type = if element_types.is_empty() {
         Type::array()
-    } else if element_types.len() == 1 {
-        let elem_type = element_types.into_iter().next().unwrap();
-        Type::array_of(elem_type)
     } else {
         let types_vec: Vec<Type> = element_types.into_iter().collect();
-        let union_type = Type::Union(types_vec);
-        Type::array_of(union_type)
+        Type::array_of(Type::union_of(types_vec))
     };
 
     Some(genv.new_source(array_type))
@@ -176,18 +172,8 @@ fn install_hash_literal_elements(
     let hash_type = if key_types.is_empty() || value_types.is_empty() {
         Type::hash()
     } else {
-        let key_type = if key_types.len() == 1 {
-            key_types.into_iter().next().unwrap()
-        } else {
-            let types_vec: Vec<Type> = key_types.into_iter().collect();
-            Type::Union(types_vec)
-        };
-        let value_type = if value_types.len() == 1 {
-            value_types.into_iter().next().unwrap()
-        } else {
-            let types_vec: Vec<Type> = value_types.into_iter().collect();
-            Type::Union(types_vec)
-        };
+        let key_type = Type::union_of(key_types.into_iter().collect());
+        let value_type = Type::union_of(value_types.into_iter().collect());
         Type::hash_of(key_type, value_type)
     };
 

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -276,6 +276,17 @@ impl Type {
             type_args: vec![element_type],
         }
     }
+
+    /// Collapse a Vec<Type> into a single Type or Union.
+    /// Returns the single element if len==1, or Union if len>1.
+    /// Panics if the vec is empty.
+    pub fn union_of(mut types: Vec<Type>) -> Self {
+        match types.len() {
+            0 => panic!("union_of called with empty types"),
+            1 => types.pop().unwrap(),
+            _ => Type::Union(types),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/test/exception_test.rb
+++ b/test/exception_test.rb
@@ -42,6 +42,49 @@ class ExceptionTest < Minitest::Test
     refute_includes type_str, "String"
   end
 
+  def test_rescue_variable_typed_as_specific_exception
+    source = <<~RUBY
+      x = begin
+            "hello"
+          rescue ArgumentError => e
+            e
+          end
+    RUBY
+
+    types = infer(source)
+    type_str = types["x"]
+    assert_includes type_str, "ArgumentError"
+  end
+
+  def test_rescue_variable_typed_as_union_of_exceptions
+    source = <<~RUBY
+      x = begin
+            "hello"
+          rescue TypeError, NameError => e
+            e
+          end
+    RUBY
+
+    types = infer(source)
+    type_str = types["x"]
+    assert_includes type_str, "TypeError"
+    assert_includes type_str, "NameError"
+  end
+
+  def test_rescue_without_exception_class_defaults_to_standard_error
+    source = <<~RUBY
+      x = begin
+            "hello"
+          rescue => e
+            e
+          end
+    RUBY
+
+    types = infer(source)
+    type_str = types["x"]
+    assert_includes type_str, "StandardError"
+  end
+
   def test_rescue_modifier_union_type
     source = <<~RUBY
       x = "hello" rescue 42
@@ -96,6 +139,26 @@ class ExceptionTest < Minitest::Test
   # ============================================
   # Error Detection (check CLI)
   # ============================================
+
+  def test_rescue_with_specific_exception_returns_string
+    source = <<~RUBY
+      class Catcher
+        def catch_it
+          begin
+            "result"
+          rescue ArgumentError
+            "fallback"
+          end
+        end
+
+        def run
+          self.catch_it.upcase
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
 
   def test_rescue_branch_type_error
     source = <<~RUBY


### PR DESCRIPTION
Previously, rescue variables (rescue SomeError => e) were always typed as StandardError regardless of the declared exception class.
This caused false negatives when calling methods specific to the caught exception.

Add Type::union_of helper to collapse Vec<Type> into a single or union type, and use it to simplify array/hash literal type construction as well