### PR TITLE
Add module include support for mixin method resolution

### DIFF
--- a/core/src/analyzer/dispatch.rs
+++ b/core/src/analyzer/dispatch.rs
@@ -62,6 +62,10 @@ pub enum NeedsChildKind<'a> {
         kind: AttrKind,
         attr_names: Vec<String>,
     },
+    /// include declaration: `include Greetable, Enumerable`
+    IncludeDeclaration {
+        module_names: Vec<String>,
+    },
 }
 
 /// First pass: check if node can be handled immediately without child processing
@@ -189,6 +193,25 @@ pub fn dispatch_needs_child<'a>(node: &Node<'a>, source: &str) -> Option<NeedsCh
                 return None;
             }
 
+            if method_name == "include" {
+                let module_names: Vec<String> = call_node
+                    .arguments()
+                    .map(|args| {
+                        args.arguments()
+                            .iter()
+                            .filter_map(|arg| {
+                                super::definitions::extract_constant_path(&arg)
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                if !module_names.is_empty() {
+                    return Some(NeedsChildKind::IncludeDeclaration { module_names });
+                }
+                return None;
+            }
+
             let prism_location = call_node
                 .message_loc()
                 .unwrap_or_else(|| node.location());
@@ -260,6 +283,16 @@ pub(crate) fn process_needs_child(
         }
         NeedsChildKind::AttrDeclaration { kind, attr_names } => {
             super::attributes::process_attr_declaration(genv, kind, attr_names);
+            None
+        }
+        NeedsChildKind::IncludeDeclaration { module_names } => {
+            if let Some(class_name) = genv.scope_manager.current_qualified_name() {
+                // Ruby processes `include A, B` right-to-left (B first, then A on top),
+                // so A ends up with higher MRO priority. Reverse to match this behavior.
+                for module_name in module_names.iter().rev() {
+                    genv.record_include(&class_name, module_name);
+                }
+            }
             None
         }
     }
@@ -1131,6 +1164,227 @@ User.new.profile(name: "Alice", age: 30)
         let info = genv
             .resolve_method(&Type::instance("User"), "profile")
             .expect("User#profile should be registered");
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "String");
+    }
+
+    // === Include (mixin) tests ===
+
+    // Test 31: Basic include — module method resolved on class instance
+    #[test]
+    fn test_include_basic() {
+        let source = r#"
+module Greetable
+  def greet
+    "Hello!"
+  end
+end
+
+class User
+  include Greetable
+end
+
+User.new.greet
+"#;
+        let genv = analyze(source);
+        assert!(
+            genv.type_errors.is_empty(),
+            "include should resolve Greetable#greet: {:?}",
+            genv.type_errors
+        );
+    }
+
+    // Test 32: Include method return type inference
+    #[test]
+    fn test_include_method_return_type() {
+        let source = r#"
+module Greetable
+  def greet
+    "Hello!"
+  end
+end
+
+class User
+  include Greetable
+
+  def say_hello
+    greet
+  end
+end
+"#;
+        let genv = analyze(source);
+
+        let info = genv
+            .resolve_method(&Type::instance("User"), "say_hello")
+            .expect("User#say_hello should be registered");
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "String");
+    }
+
+    // Test 33: Multiple includes — last included module has priority
+    #[test]
+    fn test_include_multiple_modules() {
+        let source = r#"
+module A
+  def foo
+    "from A"
+  end
+end
+
+module B
+  def foo
+    42
+  end
+end
+
+class User
+  include A
+  include B
+end
+
+User.new.foo
+"#;
+        let genv = analyze(source);
+        assert!(genv.type_errors.is_empty());
+
+        // B is included last → B#foo (Integer) should be resolved
+        let info = genv
+            .resolve_method(&Type::instance("User"), "foo")
+            .expect("User#foo should be resolved via include");
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "Integer");
+    }
+
+    // Test 34: Class's own method takes priority over included module
+    #[test]
+    fn test_include_class_method_priority() {
+        let source = r#"
+module Greetable
+  def greet
+    "Hello from module!"
+  end
+end
+
+class User
+  include Greetable
+
+  def greet
+    42
+  end
+end
+
+User.new.greet
+"#;
+        let genv = analyze(source);
+
+        let info = genv
+            .resolve_method(&Type::instance("User"), "greet")
+            .expect("User#greet should be resolved");
+        let ret_vtx = info.return_vertex.unwrap();
+        // Class's own method (Integer) takes priority
+        assert_eq!(get_type_show(&genv, ret_vtx), "Integer");
+    }
+
+    // Test 35: Include with qualified module name
+    #[test]
+    fn test_include_qualified_module() {
+        let source = r#"
+module Api
+  module Helpers
+    def help
+      "help"
+    end
+  end
+end
+
+class User
+  include Api::Helpers
+end
+
+User.new.help
+"#;
+        let genv = analyze(source);
+        assert!(
+            genv.type_errors.is_empty(),
+            "include Api::Helpers should resolve: {:?}",
+            genv.type_errors
+        );
+    }
+
+    // Test 36: Include with simultaneous multiple modules
+    #[test]
+    fn test_include_simultaneous_multiple() {
+        let source = r#"
+module A
+  def a_method
+    "a"
+  end
+end
+
+module B
+  def b_method
+    42
+  end
+end
+
+class User
+  include A, B
+end
+
+User.new.a_method
+User.new.b_method
+"#;
+        let genv = analyze(source);
+        assert!(
+            genv.type_errors.is_empty(),
+            "include A, B should resolve both modules: {:?}",
+            genv.type_errors
+        );
+    }
+
+    // Test 37: Include with unknown module (no crash)
+    #[test]
+    fn test_include_unknown_module() {
+        let source = r#"
+class User
+  include UnknownModule
+end
+"#;
+        let genv = analyze(source);
+        // Should not panic; unknown module is recorded but methods won't resolve
+        let _ = genv;
+    }
+
+    // Test 38: Simultaneous include A, B — A has higher MRO priority (Ruby semantics)
+    #[test]
+    fn test_include_simultaneous_order() {
+        let source = r#"
+module A
+  def foo
+    "from A"
+  end
+end
+
+module B
+  def foo
+    42
+  end
+end
+
+class User
+  include A, B
+end
+
+User.new.foo
+"#;
+        let genv = analyze(source);
+        assert!(genv.type_errors.is_empty());
+
+        // Ruby's `include A, B` processes right-to-left: B first, then A on top.
+        // A has higher MRO priority → A#foo (String) should be resolved.
+        let info = genv
+            .resolve_method(&Type::instance("User"), "foo")
+            .expect("User#foo should be resolved via include");
         let ret_vtx = info.return_vertex.unwrap();
         assert_eq!(get_type_show(&genv, ret_vtx), "String");
     }

--- a/core/src/env/global_env.rs
+++ b/core/src/env/global_env.rs
@@ -37,6 +37,9 @@ pub struct GlobalEnv {
 
     /// Scope management
     pub scope_manager: ScopeManager,
+
+    /// Module inclusions: class_name → Vec<module_name> (in include order)
+    module_inclusions: HashMap<String, Vec<String>>,
 }
 
 impl GlobalEnv {
@@ -47,6 +50,7 @@ impl GlobalEnv {
             method_registry: MethodRegistry::new(),
             type_errors: Vec::new(),
             scope_manager: ScopeManager::new(),
+            module_inclusions: HashMap::new(),
         }
     }
 
@@ -158,7 +162,16 @@ impl GlobalEnv {
 
     /// Resolve method
     pub fn resolve_method(&self, recv_ty: &Type, method_name: &str) -> Option<&MethodInfo> {
-        self.method_registry.resolve(recv_ty, method_name)
+        self.method_registry
+            .resolve(recv_ty, method_name, &self.module_inclusions)
+    }
+
+    /// Record that a class includes a module
+    pub fn record_include(&mut self, class_name: &str, module_name: &str) {
+        self.module_inclusions
+            .entry(class_name.to_string())
+            .or_default()
+            .push(module_name.to_string());
     }
 
     /// Register built-in method

--- a/core/src/env/method_registry.rs
+++ b/core/src/env/method_registry.rs
@@ -84,9 +84,13 @@ impl MethodRegistry {
     /// Returns a list of types to search in order:
     /// 1. Exact receiver type
     /// 2. Generic → base class (e.g., Array[Integer] → Array)
-    /// 3. Object (for Instance/Generic types only)
-    /// 4. Kernel (for Instance/Generic types only)
-    fn fallback_chain(recv_ty: &Type) -> SmallVec<[Type; 4]> {
+    /// 3. Included modules (last included first, matching Ruby MRO)
+    /// 4. Object (for Instance/Generic types only)
+    /// 5. Kernel (for Instance/Generic types only)
+    fn fallback_chain(
+        recv_ty: &Type,
+        inclusions: &HashMap<String, Vec<String>>,
+    ) -> SmallVec<[Type; 8]> {
         let mut chain = SmallVec::new();
         chain.push(recv_ty.clone());
 
@@ -94,9 +98,17 @@ impl MethodRegistry {
             chain.push(Type::Instance { name: name.clone() });
         }
 
-        // NOTE: Kernel is a module, not a class. Represented as Type::Instance
-        // due to lack of Type::Module variant.
+        // MRO for Instance/Generic: included modules → Object → Kernel
         if matches!(recv_ty, Type::Instance { .. } | Type::Generic { .. }) {
+            // Included modules (reverse order = last included has highest priority)
+            if let Some(class_name) = recv_ty.base_class_name() {
+                if let Some(modules) = inclusions.get(class_name) {
+                    for module_name in modules.iter().rev() {
+                        chain.push(Type::instance(module_name));
+                    }
+                }
+            }
+
             chain.push(Type::instance(OBJECT_CLASS));
             chain.push(Type::instance(KERNEL_MODULE));
         }
@@ -106,11 +118,17 @@ impl MethodRegistry {
 
     /// Resolve a method for a receiver type
     ///
-    /// Searches the MRO fallback chain: exact type → base class (for generics) → Object → Kernel.
+    /// Searches the MRO fallback chain: exact type → base class (for generics)
+    /// → included modules → Object → Kernel.
     /// For non-instance types (Singleton, Nil, Union, Bot), only exact match is attempted.
-    pub fn resolve(&self, recv_ty: &Type, method_name: &str) -> Option<&MethodInfo> {
+    pub fn resolve(
+        &self,
+        recv_ty: &Type,
+        method_name: &str,
+        inclusions: &HashMap<String, Vec<String>>,
+    ) -> Option<&MethodInfo> {
         let method_key = method_name.to_string();
-        Self::fallback_chain(recv_ty)
+        Self::fallback_chain(recv_ty, inclusions)
             .into_iter()
             .find_map(|ty| self.methods.get(&(ty, method_key.clone())))
     }
@@ -125,14 +143,14 @@ mod tests {
         let mut registry = MethodRegistry::new();
         registry.register(Type::string(), "length", Type::integer());
 
-        let info = registry.resolve(&Type::string(), "length").unwrap();
+        let info = registry.resolve(&Type::string(), "length", &HashMap::new()).unwrap();
         assert_eq!(info.return_type.base_class_name(), Some("Integer"));
     }
 
     #[test]
     fn test_resolve_not_found() {
         let registry = MethodRegistry::new();
-        assert!(registry.resolve(&Type::string(), "unknown").is_none());
+        assert!(registry.resolve(&Type::string(), "unknown", &HashMap::new()).is_none());
     }
 
     #[test]
@@ -141,7 +159,7 @@ mod tests {
         let return_vtx = VertexId(42);
         registry.register_user_method(Type::instance("User"), "name", return_vtx, vec![], None);
 
-        let info = registry.resolve(&Type::instance("User"), "name").unwrap();
+        let info = registry.resolve(&Type::instance("User"), "name", &HashMap::new()).unwrap();
         assert_eq!(info.return_vertex, Some(VertexId(42)));
         assert_eq!(info.return_type, Type::Bot);
     }
@@ -159,7 +177,7 @@ mod tests {
             None,
         );
 
-        let info = registry.resolve(&Type::instance("Calc"), "add").unwrap();
+        let info = registry.resolve(&Type::instance("Calc"), "add", &HashMap::new()).unwrap();
         assert_eq!(info.return_vertex, Some(VertexId(10)));
         let pvs = info.param_vertices.as_ref().unwrap();
         assert_eq!(pvs.len(), 2);
@@ -173,7 +191,7 @@ mod tests {
     fn test_resolve_falls_back_to_object() {
         let mut registry = MethodRegistry::new();
         registry.register(Type::instance("Object"), "nil?", Type::instance("TrueClass"));
-        let info = registry.resolve(&Type::instance("CustomClass"), "nil?").unwrap();
+        let info = registry.resolve(&Type::instance("CustomClass"), "nil?", &HashMap::new()).unwrap();
         assert_eq!(info.return_type.base_class_name(), Some("TrueClass"));
     }
 
@@ -181,7 +199,7 @@ mod tests {
     fn test_resolve_falls_back_to_kernel() {
         let mut registry = MethodRegistry::new();
         registry.register(Type::instance("Kernel"), "puts", Type::Nil);
-        let info = registry.resolve(&Type::instance("MyApp"), "puts").unwrap();
+        let info = registry.resolve(&Type::instance("MyApp"), "puts", &HashMap::new()).unwrap();
         assert_eq!(info.return_type, Type::Nil);
     }
 
@@ -190,7 +208,7 @@ mod tests {
         let mut registry = MethodRegistry::new();
         registry.register(Type::instance("Object"), "to_s", Type::string());
         registry.register(Type::instance("Kernel"), "to_s", Type::integer());
-        let info = registry.resolve(&Type::instance("Anything"), "to_s").unwrap();
+        let info = registry.resolve(&Type::instance("Anything"), "to_s", &HashMap::new()).unwrap();
         assert_eq!(info.return_type.base_class_name(), Some("String"));
     }
 
@@ -199,7 +217,7 @@ mod tests {
         let mut registry = MethodRegistry::new();
         registry.register(Type::string(), "length", Type::integer());
         registry.register(Type::instance("Object"), "length", Type::string());
-        let info = registry.resolve(&Type::string(), "length").unwrap();
+        let info = registry.resolve(&Type::string(), "length", &HashMap::new()).unwrap();
         assert_eq!(info.return_type.base_class_name(), Some("Integer"));
     }
 
@@ -209,14 +227,14 @@ mod tests {
     fn test_singleton_type_skips_fallback() {
         let mut registry = MethodRegistry::new();
         registry.register(Type::instance("Kernel"), "puts", Type::Nil);
-        assert!(registry.resolve(&Type::singleton("User"), "puts").is_none());
+        assert!(registry.resolve(&Type::singleton("User"), "puts", &HashMap::new()).is_none());
     }
 
     #[test]
     fn test_nil_type_skips_fallback() {
         let mut registry = MethodRegistry::new();
         registry.register(Type::instance("Kernel"), "puts", Type::Nil);
-        assert!(registry.resolve(&Type::Nil, "puts").is_none());
+        assert!(registry.resolve(&Type::Nil, "puts", &HashMap::new()).is_none());
     }
 
     #[test]
@@ -224,14 +242,14 @@ mod tests {
         let mut registry = MethodRegistry::new();
         registry.register(Type::instance("Kernel"), "puts", Type::Nil);
         let union_ty = Type::Union(vec![Type::string(), Type::integer()]);
-        assert!(registry.resolve(&union_ty, "puts").is_none());
+        assert!(registry.resolve(&union_ty, "puts", &HashMap::new()).is_none());
     }
 
     #[test]
     fn test_bot_type_skips_fallback() {
         let mut registry = MethodRegistry::new();
         registry.register(Type::instance("Kernel"), "puts", Type::Nil);
-        assert!(registry.resolve(&Type::Bot, "puts").is_none());
+        assert!(registry.resolve(&Type::Bot, "puts", &HashMap::new()).is_none());
     }
 
     // --- Generic type fallback chain ---
@@ -241,7 +259,7 @@ mod tests {
         let mut registry = MethodRegistry::new();
         registry.register(Type::instance("Kernel"), "puts", Type::Nil);
         let generic_type = Type::array_of(Type::integer());
-        let info = registry.resolve(&generic_type, "puts").unwrap();
+        let info = registry.resolve(&generic_type, "puts", &HashMap::new()).unwrap();
         assert_eq!(info.return_type, Type::Nil);
     }
 
@@ -252,7 +270,7 @@ mod tests {
         registry.register(Type::instance("Kernel"), "object_id", Type::integer());
         let generic_type = Type::array_of(Type::string());
         // Array[String] → Array (none) → Object (none) → Kernel (exists)
-        let info = registry.resolve(&generic_type, "object_id").unwrap();
+        let info = registry.resolve(&generic_type, "object_id", &HashMap::new()).unwrap();
         assert_eq!(info.return_type.base_class_name(), Some("Integer"));
     }
 
@@ -262,7 +280,75 @@ mod tests {
     fn test_resolve_namespaced_class_falls_back_to_object() {
         let mut registry = MethodRegistry::new();
         registry.register(Type::instance("Object"), "class", Type::string());
-        let info = registry.resolve(&Type::instance("Api::V1::User"), "class").unwrap();
+        let info = registry.resolve(&Type::instance("Api::V1::User"), "class", &HashMap::new()).unwrap();
         assert_eq!(info.return_type.base_class_name(), Some("String"));
+    }
+
+    // --- Include (mixin) fallback ---
+
+    #[test]
+    fn test_resolve_with_include() {
+        let mut registry = MethodRegistry::new();
+        registry.register(Type::instance("Greetable"), "greet", Type::string());
+
+        let mut inclusions = HashMap::new();
+        inclusions.insert("User".to_string(), vec!["Greetable".to_string()]);
+
+        let info = registry.resolve(&Type::instance("User"), "greet", &inclusions).unwrap();
+        assert_eq!(info.return_type.base_class_name(), Some("String"));
+    }
+
+    #[test]
+    fn test_resolve_include_order() {
+        // include A; include B → B's method found first (MRO: last included wins)
+        let mut registry = MethodRegistry::new();
+        registry.register(Type::instance("A"), "foo", Type::string());
+        registry.register(Type::instance("B"), "foo", Type::integer());
+
+        let mut inclusions = HashMap::new();
+        inclusions.insert("User".to_string(), vec!["A".to_string(), "B".to_string()]);
+
+        let info = registry.resolve(&Type::instance("User"), "foo", &inclusions).unwrap();
+        assert_eq!(info.return_type.base_class_name(), Some("Integer"));
+    }
+
+    #[test]
+    fn test_resolve_class_method_over_include() {
+        // Class's own method takes priority over included module
+        let mut registry = MethodRegistry::new();
+        registry.register(Type::instance("Greetable"), "greet", Type::string());
+        registry.register(Type::instance("User"), "greet", Type::integer());
+
+        let mut inclusions = HashMap::new();
+        inclusions.insert("User".to_string(), vec!["Greetable".to_string()]);
+
+        let info = registry.resolve(&Type::instance("User"), "greet", &inclusions).unwrap();
+        assert_eq!(info.return_type.base_class_name(), Some("Integer"));
+    }
+
+    #[test]
+    fn test_resolve_include_before_object() {
+        // Included module is searched before Object in MRO
+        let mut registry = MethodRegistry::new();
+        registry.register(Type::instance("Object"), "foo", Type::string());
+        registry.register(Type::instance("MyModule"), "foo", Type::integer());
+
+        let mut inclusions = HashMap::new();
+        inclusions.insert("User".to_string(), vec!["MyModule".to_string()]);
+
+        let info = registry.resolve(&Type::instance("User"), "foo", &inclusions).unwrap();
+        assert_eq!(info.return_type.base_class_name(), Some("Integer"));
+    }
+
+    #[test]
+    fn test_singleton_type_skips_include_fallback() {
+        // include adds instance methods only — Singleton (class-level) should NOT resolve
+        let mut registry = MethodRegistry::new();
+        registry.register(Type::instance("Greetable"), "greet", Type::string());
+
+        let mut inclusions = HashMap::new();
+        inclusions.insert("User".to_string(), vec!["Greetable".to_string()]);
+
+        assert!(registry.resolve(&Type::singleton("User"), "greet", &inclusions).is_none());
     }
 }

--- a/test/include_test.rb
+++ b/test/include_test.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class IncludeTest < Minitest::Test
+  include CLITestHelper
+
+  # ============================================
+  # No Error
+  # ============================================
+
+  def test_include_basic_no_error
+    source = <<~RUBY
+      module Greetable
+        def greet
+          "Hello!"
+        end
+      end
+
+      class User
+        include Greetable
+      end
+
+      User.new.greet
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_include_receiverless_call
+    source = <<~RUBY
+      module Greetable
+        def greet
+          "Hello!"
+        end
+      end
+
+      class User
+        include Greetable
+
+        def say_hello
+          greet
+        end
+      end
+
+      User.new.say_hello
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_include_multiple_modules
+    source = <<~RUBY
+      module A
+        def a_method
+          "a"
+        end
+      end
+
+      module B
+        def b_method
+          42
+        end
+      end
+
+      class User
+        include A
+        include B
+      end
+
+      User.new.a_method
+      User.new.b_method
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_include_simultaneous
+    source = <<~RUBY
+      module A
+        def a_method
+          "a"
+        end
+      end
+
+      module B
+        def b_method
+          42
+        end
+      end
+
+      class User
+        include A, B
+      end
+
+      User.new.a_method
+      User.new.b_method
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_include_qualified_module
+    source = <<~RUBY
+      module Api
+        module Helpers
+          def help
+            "help"
+          end
+        end
+      end
+
+      class User
+        include Api::Helpers
+      end
+
+      User.new.help
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  # ============================================
+  # Error Detection
+  # ============================================
+
+  def test_include_method_type_error
+    source = <<~RUBY
+      module Greetable
+        def greet
+          "Hello!"
+        end
+      end
+
+      class User
+        include Greetable
+      end
+
+      User.new.greet.even?
+    RUBY
+
+    assert_check_error(source, method_name: 'even?', receiver_type: 'String')
+  end
+end


### PR DESCRIPTION
## Summary

- Add `include` detection in `dispatch.rs` to recognize module mixin declarations (single, multiple, qualified names)
- Track module inclusions in `GlobalEnv` via `module_inclusions: HashMap<String, Vec<String>>`
- Extend `MethodRegistry::fallback_chain` to search included modules between the class and Object, following Ruby's MRO (last included module has highest priority)
- Add 8 Rust integration tests and 6 Ruby integration tests covering basic include, multiple modules, qualified names, simultaneous include, MRO priority, and error detection

## Why

`include Greetable` was previously treated as an unknown implicit self method call, producing false `TypeError` on methods defined in included modules. This is a fundamental Ruby pattern that must be supported for practical type checking.

## Test plan

- [x] Rust unit tests: `MethodRegistry` resolve with inclusions, MRO order, class priority over include, include before Object
- [x] Rust integration tests: basic include, return type inference, multiple modules, class method priority, qualified modules, simultaneous include, unknown module safety, simultaneous include order
- [x] Ruby integration tests: basic no error, receiverless call, multiple modules, simultaneous include, qualified module, method type error detection
- [x] `cd core && cargo test --lib` — all tests pass
- [x] `bundle exec rake test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)