### PR TITLE
Add for loop type inference support

### DIFF
--- a/core/src/analyzer/install.rs
+++ b/core/src/analyzer/install.rs
@@ -15,7 +15,7 @@ use super::definitions::{process_class_node, process_def_node, process_module_no
 use super::exceptions::{process_begin_node, process_rescue_modifier_node};
 use super::dispatch::{dispatch_needs_child, dispatch_simple, process_needs_child, DispatchResult};
 use super::literals::install_literal_node;
-use super::loops::{process_until_node, process_while_node};
+use super::loops::{process_for_node, process_until_node, process_while_node};
 use super::operators::{process_and_node, process_or_node};
 use super::parentheses::process_parentheses_node;
 use super::returns::process_return_node;
@@ -94,6 +94,9 @@ pub(crate) fn install_node(
     }
     if let Some(until_node) = node.as_until_node() {
         return process_until_node(genv, lenv, changes, source, &until_node);
+    }
+    if let Some(for_node) = node.as_for_node() {
+        return process_for_node(genv, lenv, changes, source, &for_node);
     }
 
     if let Some(paren_node) = node.as_parentheses_node() {

--- a/core/src/analyzer/loops.rs
+++ b/core/src/analyzer/loops.rs
@@ -6,8 +6,9 @@
 use crate::env::{GlobalEnv, LocalEnv};
 use crate::graph::{ChangeSet, VertexId};
 use crate::types::Type;
-use ruby_prism::{UntilNode, WhileNode};
+use ruby_prism::{ForNode, UntilNode, WhileNode};
 
+use super::bytes_to_name;
 use super::install::{install_node, install_statements};
 
 /// Process WhileNode: `while predicate; statements; end`
@@ -44,6 +45,48 @@ pub(crate) fn process_until_node(
     install_node(genv, lenv, changes, source, &until_node.predicate());
 
     if let Some(stmts) = until_node.statements() {
+        install_statements(genv, lenv, changes, source, &stmts);
+    }
+
+    Some(genv.new_source(Type::Nil))
+}
+
+/// Process ForNode: `for index in collection; statements; end`
+///
+/// Ruby's `for` does NOT create a new scope — the loop variable persists
+/// after the loop. This differs from `collection.each { |x| }` which
+/// creates a block scope.
+///
+/// Returns nil (consistent with while/until; Ruby's for returns the
+/// collection, but the return value is rarely used in practice).
+pub(crate) fn process_for_node(
+    genv: &mut GlobalEnv,
+    lenv: &mut LocalEnv,
+    changes: &mut ChangeSet,
+    source: &str,
+    for_node: &ForNode,
+) -> Option<VertexId> {
+    let collection_vtx = install_node(genv, lenv, changes, source, &for_node.collection());
+
+    // TODO: MultiTargetNode (e.g., `for a, b in [[1, "x"]]`) is not yet supported
+    if let Some(target) = for_node.index().as_local_variable_target_node() {
+        let name = bytes_to_name(target.name().as_slice());
+        let var_vtx = genv.new_vertex();
+
+        // Array[T] or Range[T] → loop var gets T
+        let elem_type = collection_vtx
+            .and_then(|vtx| genv.get_source(vtx))
+            .and_then(|src| src.ty.type_args())
+            .and_then(|args| args.first().cloned());
+        if let Some(ty) = elem_type {
+            let elem_src = genv.new_source(ty);
+            genv.add_edge(elem_src, var_vtx);
+        }
+
+        lenv.new_var(name, var_vtx);
+    }
+
+    if let Some(stmts) = for_node.statements() {
         install_statements(genv, lenv, changes, source, &stmts);
     }
 
@@ -172,5 +215,87 @@ end
             .expect("Foo#bar should be registered");
         let ret_vtx = info.return_vertex.unwrap();
         assert_eq!(get_type_show(&genv, ret_vtx), "nil");
+    }
+
+    // --- for loop tests ---
+
+    #[test]
+    fn test_for_returns_nil() {
+        let source = r#"
+class Foo
+  def bar
+    for x in [1, 2, 3]
+      x
+    end
+  end
+end
+"#;
+        let genv = analyze(source);
+        let info = genv
+            .resolve_method(&Type::instance("Foo"), "bar")
+            .expect("Foo#bar should be registered");
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "nil");
+    }
+
+    #[test]
+    fn test_for_variable_type_from_array() {
+        let source = r#"
+for item in [1, 2, 3]
+  item
+end
+"#;
+        // Should not panic; loop variable is registered
+        analyze(source);
+    }
+
+    #[test]
+    fn test_for_variable_persists_after_loop() {
+        // for does NOT create a new scope — variable persists
+        let source = r#"
+class Foo
+  def bar
+    for x in [1, 2, 3]
+    end
+    x
+  end
+end
+"#;
+        // Should not panic — x is accessible after the loop
+        analyze(source);
+    }
+
+    #[test]
+    fn test_for_empty_body() {
+        let source = r#"
+class Foo
+  def bar
+    for x in [1, 2, 3]
+    end
+  end
+end
+"#;
+        let genv = analyze(source);
+        let info = genv
+            .resolve_method(&Type::instance("Foo"), "bar")
+            .expect("Foo#bar should be registered");
+        let ret_vtx = info.return_vertex.unwrap();
+        assert_eq!(get_type_show(&genv, ret_vtx), "nil");
+    }
+
+    #[test]
+    fn test_for_with_method_call_in_body() {
+        // Should not panic — method call on loop variable is processed
+        // (type error check requires RBS, covered by Ruby integration test)
+        let source = r#"
+class Foo
+  def bar
+    for item in ["hello", "world"]
+      item.upcase
+    end
+  end
+end
+"#;
+        analyze(source);
     }
 }

--- a/test/loop_test.rb
+++ b/test/loop_test.rb
@@ -37,6 +37,20 @@ class LoopTest < Minitest::Test
     assert_no_check_errors(source)
   end
 
+  def test_for_loop_basic_no_error
+    source = <<~RUBY
+      class Foo
+        def bar
+          for item in ["hello", "world"]
+            item.upcase
+          end
+        end
+      end
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
   # ============================================
   # Error Detection (check CLI)
   # ============================================
@@ -51,6 +65,20 @@ class LoopTest < Minitest::Test
         def baz
           while true
             self.bar.upcase
+          end
+        end
+      end
+    RUBY
+
+    assert_check_error(source, method_name: 'upcase', receiver_type: 'Integer')
+  end
+
+  def test_for_loop_detects_type_error
+    source = <<~RUBY
+      class Foo
+        def bar
+          for item in [1, 2, 3]
+            item.upcase
           end
         end
       end


### PR DESCRIPTION
## Summary

- Add `process_for_node` in `loops.rs` to handle `ForNode` AST nodes, extracting element types from `Array[T]` / `Range[T]` collection literals and registering loop variables in the current scope
- Add `ForNode` dispatch in `install.rs` so `for` loops are no longer silently ignored
- Add Rust unit tests (5 cases: return type, variable typing, scope persistence, empty body, method calls) and Ruby integration tests (no-error and type-error detection)

## Why

`ForNode` was completely unhandled in the AST installer — `for x in [1, 2, 3]` would silently skip type analysis, leaving loop variables untyped. This meant method calls like `item.upcase` inside `for` loops could not be validated, creating a gap in type coverage for Ruby code that uses `for` iteration.

## Design decisions

- **Returns `nil`** (consistent with `while`/`until`) rather than the collection, since the return value of `for` is rarely used in practice
- **No new scope** — `for` in Ruby does not create a block scope, so the loop variable correctly persists after the loop
- **Immediate edge propagation** (`genv.add_edge`) for loop variable types, since they are determined at install time from literal collections

## Test plan

- [x] Rust unit tests: `test_for_returns_nil`, `test_for_variable_type_from_array`, `test_for_variable_persists_after_loop`, `test_for_empty_body`, `test_for_with_method_call_in_body`
- [x] Ruby integration tests: `test_for_loop_basic_no_error`, `test_for_loop_detects_type_error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)