### PR TITLE
Release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.9] - 2026-03-15
+
+### Added
+
+- Add linter CI workflow for Clippy and RuboCop ([#61](https://github.com/dak2/method-ray/pull/61))
+- Add unit tests for blocks and parameters analyzers ([#60](https://github.com/dak2/method-ray/pull/60))
+- Add super call type inference support ([#59](https://github.com/dak2/method-ray/pull/59))
+- Add for loop type inference support ([#58](https://github.com/dak2/method-ray/pull/58))
+- Add module include support for mixin method resolution ([#57](https://github.com/dak2/method-ray/pull/57))
+- Add complete multi-assignment type inference ([#56](https://github.com/dak2/method-ray/pull/56))
+- Add auto-tagging workflow for release PR merges ([#53](https://github.com/dak2/method-ray/pull/53))
+
+### Changed
+
+- Rename rust/ directory to core/ ([#55](https://github.com/dak2/method-ray/pull/55))
+- Infer actual exception types in rescue clauses ([#54](https://github.com/dak2/method-ray/pull/54))
+
 ## [0.1.8] - 2026-03-09
 
 ### Added
@@ -123,6 +140,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 - `methodray check` - Static type checking for Ruby files
 
+[0.1.9]: https://github.com/dak2/method-ray/releases/tag/v0.1.9
 [0.1.8]: https://github.com/dak2/method-ray/releases/tag/v0.1.8
 [0.1.7]: https://github.com/dak2/method-ray/releases/tag/v0.1.7
 [0.1.6]: https://github.com/dak2/method-ray/releases/tag/v0.1.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    method-ray (0.1.8)
+    method-ray (0.1.9)
       rbs (~> 3.0)
 
 GEM
@@ -66,7 +66,7 @@ CHECKSUMS
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  method-ray (0.1.8)
+  method-ray (0.1.9)
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.1) sha256=06f6a725d2cd91e5e7f2b7c32ba143631e1f7c8ae2fb918fc4cebec187e6a688

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methodray-core"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 
 [lib]

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methodray"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 
 [lib]

--- a/lib/methodray/version.rb
+++ b/lib/methodray/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MethodRay
-  VERSION = '0.1.8'
+  VERSION = '0.1.9'
 end


### PR DESCRIPTION
## Release v0.1.9

### Added

- Add linter CI workflow for Clippy and RuboCop ([#61](https://github.com/dak2/method-ray/pull/61))
- Add unit tests for blocks and parameters analyzers ([#60](https://github.com/dak2/method-ray/pull/60))
- Add super call type inference support ([#59](https://github.com/dak2/method-ray/pull/59))
- Add for loop type inference support ([#58](https://github.com/dak2/method-ray/pull/58))
- Add module include support for mixin method resolution ([#57](https://github.com/dak2/method-ray/pull/57))
- Add complete multi-assignment type inference ([#56](https://github.com/dak2/method-ray/pull/56))
- Add auto-tagging workflow for release PR merges ([#53](https://github.com/dak2/method-ray/pull/53))

### Changed

- Rename rust/ directory to core/ ([#55](https://github.com/dak2/method-ray/pull/55))
- Infer actual exception types in rescue clauses ([#54](https://github.com/dak2/method-ray/pull/54))

### Checklist
- [x] Version bumped in `lib/methodray/version.rb`, `core/Cargo.toml`, `ext/Cargo.toml`
- [x] CHANGELOG.md updated
- [x] All tests passing
- [x] All lints passing