### PR TITLE
Add GitHub Release creation to release-tag workflow

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -33,3 +33,10 @@ jobs:
         run: |
           git tag "$TAG"
           git push origin "$TAG"
+
+      - name: Create GitHub Release
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$TAG" --generate-notes


### PR DESCRIPTION
## Summary

- Add a `Create GitHub Release` step to the release-tag workflow
- Uses `gh release create` with `--generate-notes` to automatically create a GitHub Release with auto-generated release notes when a version tag is pushed
- Eliminates the need to manually create GitHub Releases after tagging, reducing the risk of missed or inconsistent releases

## Test plan

- [ ] Verify the workflow YAML is valid by checking the Actions tab
- [ ] Trigger a release (or simulate) and confirm a GitHub Release is created with auto-generated notes
- [ ] Confirm `GH_TOKEN` permissions are sufficient for `gh release create`

🤖 Generated with [Claude Code](https://claude.com/claude-code)