### PR TITLE
Fix release workflow to include gem assets

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -34,9 +34,9 @@ jobs:
           git tag "$TAG"
           git push origin "$TAG"
 
-      - name: Create GitHub Release
+      - name: Trigger release workflow
         env:
           TAG: ${{ steps.version.outputs.tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "$TAG" --generate-notes
+          gh workflow run release.yml --ref "$TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- **release-tag.yml**: Replace `gh release create` with `gh workflow run release.yml --ref "$TAG"` to delegate GitHub Release creation to the release workflow that actually builds gems
- **release.yml**: Add `workflow_dispatch` trigger so it can be invoked explicitly from release-tag.yml

## Why

When release-tag.yml creates a tag using `GITHUB_TOKEN`, GitHub Actions does not trigger other workflows listening for tag push events (this is a known platform limitation to prevent infinite loops). As a result, release.yml — which builds native gems and attaches them to the GitHub Release — was never executed for v0.1.9, leaving the release without gem assets.

By having release-tag.yml explicitly trigger release.yml via `workflow_dispatch`, we ensure the full build-and-release pipeline runs correctly.

## Test plan

- [ ] Merge this PR
- [ ] On next release PR merge, verify release-tag.yml triggers release.yml
- [ ] Verify GitHub Release includes all gem files (source, x86_64-linux, aarch64-linux, arm64-darwin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)