### PR TITLE
Add extend support for module methods as class methods

### DIFF
--- a/core/src/analyzer/dispatch.rs
+++ b/core/src/analyzer/dispatch.rs
@@ -103,10 +103,18 @@ pub enum NeedsChildKind<'a> {
         kind: AttrKind,
         attr_names: Vec<String>,
     },
-    /// include declaration: `include Greetable, Enumerable`
-    IncludeDeclaration {
+    /// include / extend declaration: `include Greetable`, `extend ClassMethods`
+    ModuleMixinDeclaration {
         module_names: Vec<String>,
+        kind: MixinKind,
     },
+}
+
+/// Kind of module mixin (include or extend)
+#[derive(Debug, Clone, Copy)]
+pub enum MixinKind {
+    Include,
+    Extend,
 }
 
 /// First pass: check if node can be handled immediately without child processing
@@ -174,6 +182,19 @@ fn extract_symbol_names(call_node: &ruby_prism::CallNode) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Extract module names from include/extend arguments
+fn extract_mixin_module_names(call_node: &ruby_prism::CallNode) -> Vec<String> {
+    call_node
+        .arguments()
+        .map(|args| {
+            args.arguments()
+                .iter()
+                .filter_map(|arg| super::definitions::extract_constant_path(&arg))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Check if node needs child processing
 pub fn dispatch_needs_child<'a>(node: &Node<'a>, source: &str) -> Option<NeedsChildKind<'a>> {
     // Instance variable write: @name = value
@@ -235,21 +256,16 @@ pub fn dispatch_needs_child<'a>(node: &Node<'a>, source: &str) -> Option<NeedsCh
                 return None;
             }
 
-            if method_name == "include" {
-                let module_names: Vec<String> = call_node
-                    .arguments()
-                    .map(|args| {
-                        args.arguments()
-                            .iter()
-                            .filter_map(|arg| {
-                                super::definitions::extract_constant_path(&arg)
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default();
+            let mixin_kind = match method_name.as_str() {
+                "include" => Some(MixinKind::Include),
+                "extend" => Some(MixinKind::Extend),
+                _ => None,
+            };
 
+            if let Some(kind) = mixin_kind {
+                let module_names = extract_mixin_module_names(&call_node);
                 if !module_names.is_empty() {
-                    return Some(NeedsChildKind::IncludeDeclaration { module_names });
+                    return Some(NeedsChildKind::ModuleMixinDeclaration { module_names, kind });
                 }
                 return None;
             }
@@ -329,12 +345,15 @@ pub(crate) fn process_needs_child(
             super::attributes::process_attr_declaration(genv, kind, attr_names);
             None
         }
-        NeedsChildKind::IncludeDeclaration { module_names } => {
+        NeedsChildKind::ModuleMixinDeclaration { module_names, kind } => {
             if let Some(class_name) = genv.scope_manager.current_qualified_name() {
-                // Ruby processes `include A, B` right-to-left (B first, then A on top),
+                // Ruby processes `include/extend A, B` right-to-left (B first, then A on top),
                 // so A ends up with higher MRO priority. Reverse to match this behavior.
                 for module_name in module_names.iter().rev() {
-                    genv.record_include(&class_name, module_name);
+                    match kind {
+                        MixinKind::Include => genv.record_include(&class_name, module_name),
+                        MixinKind::Extend => genv.record_extend(&class_name, module_name),
+                    }
                 }
             }
             None
@@ -1560,5 +1579,174 @@ User.new&.profile&.name
             "chained safe navigation should not produce type errors: {:?}",
             genv.type_errors
         );
+    }
+
+    // === Extend tests ===
+
+    #[test]
+    fn test_extend_basic() {
+        let source = r#"
+module ClassMethods
+  def find(id)
+    "found"
+  end
+end
+
+class User
+  extend ClassMethods
+end
+
+User.find(1)
+"#;
+        let genv = analyze(source);
+        assert!(
+            genv.type_errors.is_empty(),
+            "User.find should resolve via extend ClassMethods: {:?}",
+            genv.type_errors
+        );
+    }
+
+    #[test]
+    fn test_extend_does_not_affect_instance() {
+        let source = r#"
+module ClassMethods
+  def find(id)
+    "found"
+  end
+end
+
+class User
+  extend ClassMethods
+end
+
+User.new.find(1)
+"#;
+        let genv = analyze(source);
+        // extend does not add instance methods, so User.new.find should error
+        assert!(!genv.type_errors.is_empty());
+    }
+
+    #[test]
+    fn test_extend_qualified_module() {
+        let source = r#"
+module Api
+  module ClassHelpers
+    def search(query)
+      "results"
+    end
+  end
+end
+
+class User
+  extend Api::ClassHelpers
+end
+
+User.search("test")
+"#;
+        let genv = analyze(source);
+        assert!(
+            genv.type_errors.is_empty(),
+            "User.search should resolve via extend Api::ClassHelpers: {:?}",
+            genv.type_errors
+        );
+    }
+
+    #[test]
+    fn test_extend_multiple_modules() {
+        let source = r#"
+module A
+  def a_method
+    "a"
+  end
+end
+
+module B
+  def b_method
+    42
+  end
+end
+
+class User
+  extend A, B
+end
+
+User.a_method
+User.b_method
+"#;
+        let genv = analyze(source);
+        assert!(
+            genv.type_errors.is_empty(),
+            "User.a_method and User.b_method should resolve via extend: {:?}",
+            genv.type_errors
+        );
+    }
+
+    #[test]
+    fn test_extend_simultaneous_order() {
+        // extend A, B — A should have higher priority (Ruby processes right-to-left)
+        let source = r#"
+module A
+  def foo
+    "from_a"
+  end
+end
+
+module B
+  def foo
+    42
+  end
+end
+
+class User
+  extend A, B
+end
+
+User.foo
+"#;
+        let genv = analyze(source);
+        assert!(
+            genv.type_errors.is_empty(),
+            "User.foo should resolve via extend A, B: {:?}",
+            genv.type_errors
+        );
+    }
+
+    #[test]
+    fn test_extend_def_self_takes_priority() {
+        let source = r#"
+module ClassMethods
+  def find(id)
+    "found"
+  end
+end
+
+class User
+  extend ClassMethods
+
+  def self.find(id)
+    42
+  end
+end
+
+User.find(1)
+"#;
+        let genv = analyze(source);
+        assert!(
+            genv.type_errors.is_empty(),
+            "def self.find should take priority over extend: {:?}",
+            genv.type_errors
+        );
+    }
+
+    #[test]
+    fn test_extend_unknown_module_no_panic() {
+        let source = r#"
+class User
+  extend UnknownModule
+end
+"#;
+        let genv = analyze(source);
+        // Should not panic; unknown module is recorded but no methods are resolved
+        assert!(genv.type_errors.is_empty());
     }
 }

--- a/core/src/env/global_env.rs
+++ b/core/src/env/global_env.rs
@@ -43,6 +43,9 @@ pub struct GlobalEnv {
 
     /// Superclass map: child_class → parent_class
     superclass_map: HashMap<String, String>,
+
+    /// Module extensions: class_name → Vec<module_name> (in extend order)
+    module_extensions: HashMap<String, Vec<String>>,
 }
 
 impl GlobalEnv {
@@ -55,6 +58,7 @@ impl GlobalEnv {
             scope_manager: ScopeManager::new(),
             module_inclusions: HashMap::new(),
             superclass_map: HashMap::new(),
+            module_extensions: HashMap::new(),
         }
     }
 
@@ -169,6 +173,7 @@ impl GlobalEnv {
         let ctx = ResolutionContext {
             inclusions: &self.module_inclusions,
             superclass_map: &self.superclass_map,
+            extensions: &self.module_extensions,
         };
         self.method_registry
             .resolve(recv_ty, method_name, &ctx)
@@ -176,8 +181,20 @@ impl GlobalEnv {
 
     /// Record that a class includes a module
     pub fn record_include(&mut self, class_name: &str, module_name: &str) {
-        self.module_inclusions
-            .entry(class_name.to_string())
+        Self::record_mixin(&mut self.module_inclusions, class_name, module_name);
+    }
+
+    /// Record that a class extends a module
+    pub fn record_extend(&mut self, class_name: &str, module_name: &str) {
+        Self::record_mixin(&mut self.module_extensions, class_name, module_name);
+    }
+
+    fn record_mixin(
+        map: &mut HashMap<String, Vec<String>>,
+        class_name: &str,
+        module_name: &str,
+    ) {
+        map.entry(class_name.to_string())
             .or_default()
             .push(module_name.to_string());
     }

--- a/core/src/env/method_registry.rs
+++ b/core/src/env/method_registry.rs
@@ -9,10 +9,11 @@ use smallvec::SmallVec;
 const OBJECT_CLASS: &str = "Object";
 const KERNEL_MODULE: &str = "Kernel";
 
-/// Aggregated context for method resolution (inclusions, superclass chain)
+/// Aggregated context for method resolution (inclusions, superclass chain, extensions)
 pub struct ResolutionContext<'a> {
     pub inclusions: &'a HashMap<String, Vec<String>>,
     pub superclass_map: &'a HashMap<String, String>,
+    pub extensions: &'a HashMap<String, Vec<String>>,
 }
 
 impl<'a> ResolutionContext<'a> {
@@ -26,6 +27,7 @@ impl<'a> ResolutionContext<'a> {
         Self {
             inclusions: &EMPTY_VEC_MAP,
             superclass_map: &EMPTY_STRING_MAP,
+            extensions: &EMPTY_VEC_MAP,
         }
     }
 }
@@ -122,6 +124,7 @@ impl MethodRegistry {
     /// 4. Superclass chain: for each parent, add parent type + its included modules
     /// 5. Object (for Instance/Generic types only)
     /// 6. Kernel (for Instance/Generic types only)
+    /// 7. Extended modules (for Singleton types only, last extended has highest priority)
     fn fallback_chain(
         recv_ty: &Type,
         ctx: &ResolutionContext,
@@ -158,6 +161,11 @@ impl MethodRegistry {
             chain.push(Type::instance(KERNEL_MODULE));
         }
 
+        // Singleton type: search extended modules (extend makes module methods available as class methods)
+        if let Type::Singleton { name } = recv_ty {
+            Self::add_included_modules(&mut chain, name.full_name(), ctx.extensions);
+        }
+
         chain
     }
 
@@ -165,7 +173,8 @@ impl MethodRegistry {
     ///
     /// Searches the MRO fallback chain: exact type → base class (for generics)
     /// → included modules → superclass chain → Object → Kernel.
-    /// For non-instance types (Singleton, Nil, Union, Bot), only exact match is attempted.
+    /// For Singleton types, also searches extended modules after exact match.
+    /// For other non-instance types (Nil, Union, Bot), only exact match is attempted.
     pub fn resolve(
         &self,
         recv_ty: &Type,
@@ -341,6 +350,7 @@ mod tests {
         let ctx = ResolutionContext {
             inclusions: &inclusions,
             superclass_map: &HashMap::new(),
+            extensions: &HashMap::new(),
         };
 
         let info = registry.resolve(&Type::instance("User"), "greet", &ctx).unwrap();
@@ -359,6 +369,7 @@ mod tests {
         let ctx = ResolutionContext {
             inclusions: &inclusions,
             superclass_map: &HashMap::new(),
+            extensions: &HashMap::new(),
         };
 
         let info = registry.resolve(&Type::instance("User"), "foo", &ctx).unwrap();
@@ -377,6 +388,7 @@ mod tests {
         let ctx = ResolutionContext {
             inclusions: &inclusions,
             superclass_map: &HashMap::new(),
+            extensions: &HashMap::new(),
         };
 
         let info = registry.resolve(&Type::instance("User"), "greet", &ctx).unwrap();
@@ -395,6 +407,7 @@ mod tests {
         let ctx = ResolutionContext {
             inclusions: &inclusions,
             superclass_map: &HashMap::new(),
+            extensions: &HashMap::new(),
         };
 
         let info = registry.resolve(&Type::instance("User"), "foo", &ctx).unwrap();
@@ -412,6 +425,7 @@ mod tests {
         let ctx = ResolutionContext {
             inclusions: &inclusions,
             superclass_map: &HashMap::new(),
+            extensions: &HashMap::new(),
         };
 
         assert!(registry.resolve(&Type::singleton("User"), "greet", &ctx).is_none());
@@ -430,6 +444,7 @@ mod tests {
         let ctx = ResolutionContext {
             inclusions: &HashMap::new(),
             superclass_map: &superclass_map,
+            extensions: &HashMap::new(),
         };
 
         let info = registry.resolve(&Type::instance("Dog"), "speak", &ctx).unwrap();
@@ -448,6 +463,7 @@ mod tests {
         let ctx = ResolutionContext {
             inclusions: &HashMap::new(),
             superclass_map: &superclass_map,
+            extensions: &HashMap::new(),
         };
 
         let info = registry.resolve(&Type::instance("Puppy"), "breathe", &ctx).unwrap();
@@ -466,6 +482,7 @@ mod tests {
         let ctx = ResolutionContext {
             inclusions: &HashMap::new(),
             superclass_map: &superclass_map,
+            extensions: &HashMap::new(),
         };
 
         let info = registry.resolve(&Type::instance("Dog"), "speak", &ctx).unwrap();
@@ -485,6 +502,7 @@ mod tests {
         let ctx = ResolutionContext {
             inclusions: &inclusions,
             superclass_map: &superclass_map,
+            extensions: &HashMap::new(),
         };
 
         let info = registry.resolve(&Type::instance("Dog"), "greet", &ctx).unwrap();
@@ -502,9 +520,85 @@ mod tests {
         let ctx = ResolutionContext {
             inclusions: &HashMap::new(),
             superclass_map: &superclass_map,
+            extensions: &HashMap::new(),
         };
 
         // Should not hang; just returns None
         assert!(registry.resolve(&Type::instance("A"), "missing", &ctx).is_none());
+    }
+
+    // --- Extend (module extension) tests ---
+
+    #[test]
+    fn test_resolve_with_extend() {
+        let mut registry = MethodRegistry::new();
+        registry.register(Type::instance("ClassMethods"), "find", Type::string());
+
+        let mut extensions = HashMap::new();
+        extensions.insert("User".to_string(), vec!["ClassMethods".to_string()]);
+        let ctx = ResolutionContext {
+            inclusions: &HashMap::new(),
+            superclass_map: &HashMap::new(),
+            extensions: &extensions,
+        };
+
+        let info = registry.resolve(&Type::singleton("User"), "find", &ctx).unwrap();
+        assert_eq!(info.return_type.base_class_name(), Some("String"));
+    }
+
+    #[test]
+    fn test_resolve_extend_order() {
+        // extend A; extend B → B has higher priority (last extended wins)
+        let mut registry = MethodRegistry::new();
+        registry.register(Type::instance("A"), "foo", Type::string());
+        registry.register(Type::instance("B"), "foo", Type::integer());
+
+        let mut extensions = HashMap::new();
+        extensions.insert("User".to_string(), vec!["A".to_string(), "B".to_string()]);
+        let ctx = ResolutionContext {
+            inclusions: &HashMap::new(),
+            superclass_map: &HashMap::new(),
+            extensions: &extensions,
+        };
+
+        let info = registry.resolve(&Type::singleton("User"), "foo", &ctx).unwrap();
+        // B is extended last → higher priority
+        assert_eq!(info.return_type.base_class_name(), Some("Integer"));
+    }
+
+    #[test]
+    fn test_resolve_extend_does_not_affect_instance() {
+        let mut registry = MethodRegistry::new();
+        registry.register(Type::instance("ClassMethods"), "find", Type::string());
+
+        let mut extensions = HashMap::new();
+        extensions.insert("User".to_string(), vec!["ClassMethods".to_string()]);
+        let ctx = ResolutionContext {
+            inclusions: &HashMap::new(),
+            superclass_map: &HashMap::new(),
+            extensions: &extensions,
+        };
+
+        // Instance type should NOT resolve extended module methods
+        assert!(registry.resolve(&Type::instance("User"), "find", &ctx).is_none());
+    }
+
+    #[test]
+    fn test_resolve_def_self_over_extend() {
+        let mut registry = MethodRegistry::new();
+        registry.register(Type::instance("ClassMethods"), "find", Type::string());
+        registry.register(Type::singleton("User"), "find", Type::integer());
+
+        let mut extensions = HashMap::new();
+        extensions.insert("User".to_string(), vec!["ClassMethods".to_string()]);
+        let ctx = ResolutionContext {
+            inclusions: &HashMap::new(),
+            superclass_map: &HashMap::new(),
+            extensions: &extensions,
+        };
+
+        let info = registry.resolve(&Type::singleton("User"), "find", &ctx).unwrap();
+        // def self.find (exact match) takes priority over extend
+        assert_eq!(info.return_type.base_class_name(), Some("Integer"));
     }
 }

--- a/test/extend_test.rb
+++ b/test/extend_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ExtendTest < Minitest::Test
+  include CLITestHelper
+
+  # ============================================
+  # No Error
+  # ============================================
+
+  def test_extend_basic_no_error
+    source = <<~RUBY
+      module ClassMethods
+        def find(id)
+          "found"
+        end
+      end
+
+      class User
+        extend ClassMethods
+      end
+
+      User.find(1)
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_extend_multiple_modules
+    source = <<~RUBY
+      module A
+        def a_method
+          "a"
+        end
+      end
+
+      module B
+        def b_method
+          42
+        end
+      end
+
+      class User
+        extend A, B
+      end
+
+      User.a_method
+      User.b_method
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  def test_extend_qualified_module
+    source = <<~RUBY
+      module Api
+        module ClassHelpers
+          def search(query)
+            "results"
+          end
+        end
+      end
+
+      class User
+        extend Api::ClassHelpers
+      end
+
+      User.search("test")
+    RUBY
+
+    assert_no_check_errors(source)
+  end
+
+  # ============================================
+  # Error Detection
+  # ============================================
+
+  def test_extend_does_not_affect_instance
+    source = <<~RUBY
+      module ClassMethods
+        def find(id)
+          "found"
+        end
+      end
+
+      class User
+        extend ClassMethods
+      end
+
+      User.new.find(1)
+    RUBY
+
+    assert_check_error(source, method_name: 'find', receiver_type: 'User')
+  end
+end


### PR DESCRIPTION
## Motivation

`extend ModuleName` makes module instance methods available as class methods, but Method-Ray currently reports false positives (e.g., `User.find` → "undefined method") because Singleton type resolution has no fallback for extended modules. This is a common Ruby pattern used widely in Rails and other frameworks.

## Changes

- Add `MixinKind` enum to unify include/extend handling, replacing `IncludeDeclaration` with `ModuleMixinDeclaration`
- Extract `extract_mixin_module_names` helper to eliminate code duplication between include and extend
- Add `module_extensions` field to `GlobalEnv` with `record_extend()` method and shared `record_mixin` helper
- Add `extensions` to `ResolutionContext` and search extended modules in `fallback_chain()` for `Type::Singleton` types
- `def self.method` takes priority over extend (exact match first)

## Checked

- [x] Rust unit tests — method_registry: 4 extend cases, dispatch: 7 extend cases
- [x] Ruby integration test — `test/extend_test.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)