### PR TITLE
Tighten analyzer function visibility

### DIFF
--- a/core/src/analyzer/calls.rs
+++ b/core/src/analyzer/calls.rs
@@ -12,7 +12,7 @@ use crate::graph::{MethodCallBox, VertexId};
 use crate::source_map::SourceLocation;
 
 /// Install method call and return the return value's VertexId
-pub fn install_method_call(
+pub(crate) fn install_method_call(
     genv: &mut GlobalEnv,
     recv_vtx: VertexId,
     method_name: String,

--- a/core/src/analyzer/dispatch.rs
+++ b/core/src/analyzer/dispatch.rs
@@ -59,14 +59,14 @@ pub(crate) fn collect_arguments<'a>(
 
 /// Kind of attr_* declaration
 #[derive(Debug, Clone, Copy)]
-pub enum AttrKind {
+pub(crate) enum AttrKind {
     Reader,
     Writer,
     Accessor,
 }
 
 /// Result of dispatching a simple node (no child processing needed)
-pub enum DispatchResult {
+pub(crate) enum DispatchResult {
     /// Node produced a vertex
     Vertex(VertexId),
     /// Node was not handled
@@ -74,7 +74,7 @@ pub enum DispatchResult {
 }
 
 /// Kind of child processing needed
-pub enum NeedsChildKind<'a> {
+pub(crate) enum NeedsChildKind<'a> {
     /// Instance variable write: need to process value, then call finish_ivar_write
     IvarWrite { ivar_name: String, value: Node<'a> },
     /// Local variable write: need to process value, then call finish_local_var_write
@@ -112,7 +112,7 @@ pub enum NeedsChildKind<'a> {
 
 /// Kind of module mixin (include or extend)
 #[derive(Debug, Clone, Copy)]
-pub enum MixinKind {
+pub(crate) enum MixinKind {
     Include,
     Extend,
 }
@@ -121,7 +121,7 @@ pub enum MixinKind {
 ///
 /// Note: Literals (including Array) are handled in install.rs via install_literal
 /// because Array literals need child processing for element type inference.
-pub fn dispatch_simple(genv: &mut GlobalEnv, lenv: &mut LocalEnv, node: &Node) -> DispatchResult {
+pub(crate) fn dispatch_simple(genv: &mut GlobalEnv, lenv: &mut LocalEnv, node: &Node) -> DispatchResult {
     // Instance variable read: @name
     if let Some(ivar_read) = node.as_instance_variable_read_node() {
         let ivar_name = bytes_to_name(ivar_read.name().as_slice());
@@ -196,7 +196,7 @@ fn extract_mixin_module_names(call_node: &ruby_prism::CallNode) -> Vec<String> {
 }
 
 /// Check if node needs child processing
-pub fn dispatch_needs_child<'a>(node: &Node<'a>, source: &str) -> Option<NeedsChildKind<'a>> {
+pub(crate) fn dispatch_needs_child<'a>(node: &Node<'a>, source: &str) -> Option<NeedsChildKind<'a>> {
     // Instance variable write: @name = value
     if let Some(ivar_write) = node.as_instance_variable_write_node() {
         let ivar_name = bytes_to_name(ivar_write.name().as_slice());

--- a/core/src/analyzer/parameters.rs
+++ b/core/src/analyzer/parameters.rs
@@ -24,7 +24,7 @@ use super::bytes_to_name;
 ///   name.upcase
 /// end
 /// ```
-pub fn install_required_parameter(genv: &mut GlobalEnv, lenv: &mut LocalEnv, name: String) -> VertexId {
+pub(crate) fn install_required_parameter(genv: &mut GlobalEnv, lenv: &mut LocalEnv, name: String) -> VertexId {
     // Create a vertex for the parameter (starts as Bot/untyped)
     let param_vtx = genv.new_vertex();
 
@@ -44,7 +44,7 @@ pub fn install_required_parameter(genv: &mut GlobalEnv, lenv: &mut LocalEnv, nam
 ///   name.upcase
 /// end
 /// ```
-pub fn install_optional_parameter(
+pub(crate) fn install_optional_parameter(
     genv: &mut GlobalEnv,
     lenv: &mut LocalEnv,
     _changes: &mut ChangeSet,
@@ -75,7 +75,7 @@ pub fn install_optional_parameter(
 ///   items.first
 /// end
 /// ```
-pub fn install_rest_parameter(genv: &mut GlobalEnv, lenv: &mut LocalEnv, name: String) -> VertexId {
+pub(crate) fn install_rest_parameter(genv: &mut GlobalEnv, lenv: &mut LocalEnv, name: String) -> VertexId {
     // Create a vertex for the parameter
     let param_vtx = genv.new_vertex();
 
@@ -99,7 +99,7 @@ pub fn install_rest_parameter(genv: &mut GlobalEnv, lenv: &mut LocalEnv, name: S
 ///   options[:debug]
 /// end
 /// ```
-pub fn install_keyword_rest_parameter(
+pub(crate) fn install_keyword_rest_parameter(
     genv: &mut GlobalEnv,
     lenv: &mut LocalEnv,
     name: String,

--- a/core/src/analyzer/variables.rs
+++ b/core/src/analyzer/variables.rs
@@ -10,7 +10,7 @@ use crate::graph::{ChangeSet, VertexId};
 use crate::types::Type;
 
 /// Install local variable write: x = value
-pub fn install_local_var_write(
+pub(crate) fn install_local_var_write(
     genv: &mut GlobalEnv,
     lenv: &mut LocalEnv,
     changes: &mut ChangeSet,
@@ -24,7 +24,7 @@ pub fn install_local_var_write(
 }
 
 /// Install local variable read: x
-pub fn install_local_var_read(lenv: &LocalEnv, var_name: &str) -> Option<VertexId> {
+pub(crate) fn install_local_var_read(lenv: &LocalEnv, var_name: &str) -> Option<VertexId> {
     lenv.get_var(var_name)
 }
 
@@ -33,7 +33,7 @@ pub fn install_local_var_read(lenv: &LocalEnv, var_name: &str) -> Option<VertexI
 /// If @name already has a pre-allocated VertexId (e.g., from attr_reader),
 /// an edge is added from value_vtx to the existing vertex so types propagate.
 /// Otherwise, value_vtx is registered directly as the ivar's VertexId.
-pub fn install_ivar_write(
+pub(crate) fn install_ivar_write(
     genv: &mut GlobalEnv,
     ivar_name: String,
     value_vtx: VertexId,
@@ -49,13 +49,13 @@ pub fn install_ivar_write(
 }
 
 /// Install instance variable read: @name
-pub fn install_ivar_read(genv: &GlobalEnv, ivar_name: &str) -> Option<VertexId> {
+pub(crate) fn install_ivar_read(genv: &GlobalEnv, ivar_name: &str) -> Option<VertexId> {
     genv.scope_manager.lookup_instance_var(ivar_name)
 }
 
 /// Install self node
 /// Uses the fully qualified name if available (e.g., Api::V1::User instead of just User)
-pub fn install_self(genv: &mut GlobalEnv) -> VertexId {
+pub(crate) fn install_self(genv: &mut GlobalEnv) -> VertexId {
     if let Some(qualified_name) = genv.scope_manager.current_qualified_name() {
         genv.new_source(Type::instance(&qualified_name))
     } else {


### PR DESCRIPTION
## Motivation

As part of the test strategy rethink, integration-style tests for implicit self calls, constant resolution, parameters, and definitions have been migrated from Rust to Ruby. After this migration, several analyzer functions that were previously `pub` (to be accessible from removed Rust tests) no longer need public visibility since they are only called within the crate.

## Changes

- Narrowed visibility of functions in `calls.rs`, `dispatch.rs`, `parameters.rs`, and `variables.rs` from `pub` to `pub(crate)`
- Enums `AttrKind`, `DispatchResult`, `NeedsChildKind`, `MixinKind` also narrowed to `pub(crate)`

## Checked

- [x] `cd core && cargo test --lib` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)