### PR TITLE
Release v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.10] - 2026-03-24
+
+### Added
+
+- Add safe navigation operator (`&.`) support ([#65](https://github.com/dak2/method-ray/pull/65))
+- Add inheritance chain method resolution for user-defined classes ([#66](https://github.com/dak2/method-ray/pull/66))
+- Add extend support for module methods as class methods ([#67](https://github.com/dak2/method-ray/pull/67))
+- Add pull request template ([#82](https://github.com/dak2/method-ray/pull/82))
+
+### Changed
+
+- Migrate Rust integration tests to Ruby integration tests ([#68](https://github.com/dak2/method-ray/pull/68), [#69](https://github.com/dak2/method-ray/pull/69), [#70](https://github.com/dak2/method-ray/pull/70), [#71](https://github.com/dak2/method-ray/pull/71), [#72](https://github.com/dak2/method-ray/pull/72), [#73](https://github.com/dak2/method-ray/pull/73), [#74](https://github.com/dak2/method-ray/pull/74), [#75](https://github.com/dak2/method-ray/pull/75))
+- Remove redundant Rust unit tests ([#77](https://github.com/dak2/method-ray/pull/77), [#78](https://github.com/dak2/method-ray/pull/78), [#80](https://github.com/dak2/method-ray/pull/80), [#83](https://github.com/dak2/method-ray/pull/83), [#84](https://github.com/dak2/method-ray/pull/84), [#85](https://github.com/dak2/method-ray/pull/85), [#86](https://github.com/dak2/method-ray/pull/86))
+- Simplify README to focus on core value proposition ([#76](https://github.com/dak2/method-ray/pull/76))
+
+### Fixed
+
+- Fix release workflow to include gem assets in GitHub Release ([#63](https://github.com/dak2/method-ray/pull/63), [#64](https://github.com/dak2/method-ray/pull/64))
+
 ## [0.1.9] - 2026-03-15
 
 ### Added
@@ -140,6 +159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 - `methodray check` - Static type checking for Ruby files
 
+[0.1.10]: https://github.com/dak2/method-ray/releases/tag/v0.1.10
 [0.1.9]: https://github.com/dak2/method-ray/releases/tag/v0.1.9
 [0.1.8]: https://github.com/dak2/method-ray/releases/tag/v0.1.8
 [0.1.7]: https://github.com/dak2/method-ray/releases/tag/v0.1.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    method-ray (0.1.9)
+    method-ray (0.1.10)
       rbs (~> 3.0)
 
 GEM
@@ -66,7 +66,7 @@ CHECKSUMS
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  method-ray (0.1.9)
+  method-ray (0.1.10)
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.1) sha256=06f6a725d2cd91e5e7f2b7c32ba143631e1f7c8ae2fb918fc4cebec187e6a688

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methodray-core"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 
 [lib]

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methodray"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 
 [lib]

--- a/lib/methodray/version.rb
+++ b/lib/methodray/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MethodRay
-  VERSION = '0.1.9'
+  VERSION = '0.1.10'
 end


### PR DESCRIPTION
## Motivation

Release v0.1.10 — method resolution improvements: inheritance chain, extend support, safe navigation operator.

## Changes

- Bump version to 0.1.10 (`version.rb`, `core/Cargo.toml`, `ext/Cargo.toml`)

### Added

- Add safe navigation operator (`&.`) support ([#65](https://github.com/dak2/method-ray/pull/65))
- Add inheritance chain method resolution for user-defined classes ([#66](https://github.com/dak2/method-ray/pull/66))
- Add extend support for module methods as class methods ([#67](https://github.com/dak2/method-ray/pull/67))
- Add pull request template ([#82](https://github.com/dak2/method-ray/pull/82))

### Changed

- Migrate Rust integration tests to Ruby integration tests ([#68](https://github.com/dak2/method-ray/pull/68), [#69](https://github.com/dak2/method-ray/pull/69), [#70](https://github.com/dak2/method-ray/pull/70), [#71](https://github.com/dak2/method-ray/pull/71), [#72](https://github.com/dak2/method-ray/pull/72), [#73](https://github.com/dak2/method-ray/pull/73), [#74](https://github.com/dak2/method-ray/pull/74), [#75](https://github.com/dak2/method-ray/pull/75))
- Remove redundant Rust unit tests ([#77](https://github.com/dak2/method-ray/pull/77), [#78](https://github.com/dak2/method-ray/pull/78), [#80](https://github.com/dak2/method-ray/pull/80), [#83](https://github.com/dak2/method-ray/pull/83), [#84](https://github.com/dak2/method-ray/pull/84), [#85](https://github.com/dak2/method-ray/pull/85), [#86](https://github.com/dak2/method-ray/pull/86))
- Simplify README to focus on core value proposition ([#76](https://github.com/dak2/method-ray/pull/76))

### Fixed

- Fix release workflow to include gem assets in GitHub Release ([#63](https://github.com/dak2/method-ray/pull/63), [#64](https://github.com/dak2/method-ray/pull/64))

## Checked

- [x] `cargo test --lib`
- [x] `bundle exec rake test`