### PR TITLE
Fix release workflow dispatch after tag creation

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   create-tag:
@@ -36,7 +37,7 @@ jobs:
 
       - name: Trigger release workflow
         env:
-          TAG: ${{ steps.version.outputs.tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh workflow run release.yml --ref "$TAG"
+          TAG: ${{ steps.version.outputs.tag }}
+        run: gh workflow run release.yml --ref "$TAG"
+


### PR DESCRIPTION
## Motivation

The release workflow (`release.yml`) was not triggered after `release-tag.yml` created and pushed a tag. This is because `GITHUB_TOKEN` push events do not trigger other workflows by GitHub's design to prevent recursive runs.

## Changes

- Add `actions: write` permission to allow workflow dispatch
- Explicitly trigger `release.yml` via `gh workflow run` with `workflow_dispatch` after tag push

## Checked


🤖 Generated with [Claude Code](https://claude.com/claude-code)