### PR TITLE
Add class variable type tracking

### DIFF
--- a/core/src/analyzer/dispatch.rs
+++ b/core/src/analyzer/dispatch.rs
@@ -14,8 +14,8 @@ use ruby_prism::Node;
 use super::bytes_to_name;
 use super::calls::install_method_call;
 use super::variables::{
-    install_ivar_read, install_ivar_write, install_local_var_read, install_local_var_write,
-    install_self,
+    install_class_var_read, install_class_var_write, install_ivar_read, install_ivar_write,
+    install_local_var_read, install_local_var_write, install_self,
 };
 
 /// Collect positional and keyword arguments from AST argument nodes.
@@ -77,6 +77,8 @@ pub(crate) enum DispatchResult {
 pub(crate) enum NeedsChildKind<'a> {
     /// Instance variable write: need to process value, then call finish_ivar_write
     IvarWrite { ivar_name: String, value: Node<'a> },
+    /// Class variable write: need to process value, then call install_class_var_write
+    ClassVarWrite { cvar_name: String, value: Node<'a> },
     /// Local variable write: need to process value, then call finish_local_var_write
     LocalVarWrite { var_name: String, value: Node<'a> },
     /// Method call: need to process receiver, then call finish_method_call
@@ -126,6 +128,15 @@ pub(crate) fn dispatch_simple(genv: &mut GlobalEnv, lenv: &mut LocalEnv, node: &
     if let Some(ivar_read) = node.as_instance_variable_read_node() {
         let ivar_name = bytes_to_name(ivar_read.name().as_slice());
         return match install_ivar_read(genv, &ivar_name) {
+            Some(vtx) => DispatchResult::Vertex(vtx),
+            None => DispatchResult::NotHandled,
+        };
+    }
+
+    // Class variable read: @@name
+    if let Some(cvar_read) = node.as_class_variable_read_node() {
+        let cvar_name = bytes_to_name(cvar_read.name().as_slice());
+        return match install_class_var_read(genv, &cvar_name) {
             Some(vtx) => DispatchResult::Vertex(vtx),
             None => DispatchResult::NotHandled,
         };
@@ -203,6 +214,15 @@ pub(crate) fn dispatch_needs_child<'a>(node: &Node<'a>, source: &str) -> Option<
         return Some(NeedsChildKind::IvarWrite {
             ivar_name,
             value: ivar_write.value(),
+        });
+    }
+
+    // Class variable write: @@name = value
+    if let Some(cvar_write) = node.as_class_variable_write_node() {
+        let cvar_name = bytes_to_name(cvar_write.name().as_slice());
+        return Some(NeedsChildKind::ClassVarWrite {
+            cvar_name,
+            value: cvar_write.value(),
         });
     }
 
@@ -304,6 +324,10 @@ pub(crate) fn process_needs_child(
         NeedsChildKind::IvarWrite { ivar_name, value } => {
             let value_vtx = super::install::install_node(genv, lenv, changes, source, &value)?;
             Some(finish_ivar_write(genv, ivar_name, value_vtx))
+        }
+        NeedsChildKind::ClassVarWrite { cvar_name, value } => {
+            let value_vtx = super::install::install_node(genv, lenv, changes, source, &value)?;
+            Some(install_class_var_write(genv, cvar_name, value_vtx))
         }
         NeedsChildKind::LocalVarWrite { var_name, value } => {
             let value_vtx = super::install::install_node(genv, lenv, changes, source, &value)?;

--- a/core/src/analyzer/variables.rs
+++ b/core/src/analyzer/variables.rs
@@ -3,6 +3,7 @@
 //! This module is responsible for:
 //! - Local variable read/write (x, x = value)
 //! - Instance variable read/write (@name, @name = value)
+//! - Class variable read/write (@@name, @@name = value)
 //! - self node handling
 
 use crate::env::{GlobalEnv, LocalEnv};
@@ -60,5 +61,84 @@ pub(crate) fn install_self(genv: &mut GlobalEnv) -> VertexId {
         genv.new_source(Type::instance(&qualified_name))
     } else {
         genv.new_source(Type::instance("Object"))
+    }
+}
+
+/// Install class variable write: @@name = value
+///
+/// If @@name already has a VertexId (e.g., from a previous assignment),
+/// an edge is added from value_vtx to the existing vertex so types propagate.
+/// Otherwise, value_vtx is registered directly as the cvar's VertexId.
+pub(crate) fn install_class_var_write(
+    genv: &mut GlobalEnv,
+    cvar_name: String,
+    value_vtx: VertexId,
+) -> VertexId {
+    if let Some(existing_vtx) = genv.scope_manager.lookup_class_var(&cvar_name) {
+        genv.add_edge(value_vtx, existing_vtx);
+        existing_vtx
+    } else {
+        genv.scope_manager.set_class_var_in_class(cvar_name, value_vtx);
+        value_vtx
+    }
+}
+
+/// Install class variable read: @@name
+pub(crate) fn install_class_var_read(genv: &GlobalEnv, cvar_name: &str) -> Option<VertexId> {
+    genv.scope_manager.lookup_class_var(cvar_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Type;
+
+    fn setup_class_scope(genv: &mut GlobalEnv) {
+        genv.enter_class("TestClass".to_string(), None);
+        genv.enter_method("test_method".to_string());
+    }
+
+    #[test]
+    fn test_install_class_var_write_new() {
+        let mut genv = GlobalEnv::new();
+        setup_class_scope(&mut genv);
+
+        let value_vtx = genv.new_source(Type::integer());
+        let result_vtx = install_class_var_write(&mut genv, "@@count".to_string(), value_vtx);
+
+        assert_eq!(result_vtx, value_vtx);
+    }
+
+    #[test]
+    fn test_install_class_var_read_after_write() {
+        let mut genv = GlobalEnv::new();
+        setup_class_scope(&mut genv);
+
+        let value_vtx = genv.new_source(Type::integer());
+        install_class_var_write(&mut genv, "@@count".to_string(), value_vtx);
+
+        let read_vtx = install_class_var_read(&genv, "@@count");
+        assert_eq!(read_vtx, Some(value_vtx));
+    }
+
+    #[test]
+    fn test_install_class_var_read_undefined() {
+        let genv = GlobalEnv::new();
+        assert_eq!(install_class_var_read(&genv, "@@undefined"), None);
+    }
+
+    #[test]
+    fn test_install_class_var_write_twice_merges() {
+        let mut genv = GlobalEnv::new();
+        setup_class_scope(&mut genv);
+
+        let str_vtx = genv.new_source(Type::string());
+        let vtx1 = install_class_var_write(&mut genv, "@@var".to_string(), str_vtx);
+
+        let int_vtx = genv.new_source(Type::integer());
+        let vtx2 = install_class_var_write(&mut genv, "@@var".to_string(), int_vtx);
+
+        // Second write returns the same VertexId (edge added, not overwritten)
+        assert_eq!(vtx1, vtx2);
     }
 }

--- a/core/src/env/scope.rs
+++ b/core/src/env/scope.rs
@@ -76,6 +76,16 @@ impl Scope {
     pub fn get_instance_var(&self, name: &str) -> Option<VertexId> {
         self.instance_vars.get(name).copied()
     }
+
+    /// Add class variable
+    pub fn set_class_var(&mut self, name: String, vtx: VertexId) {
+        self.class_vars.insert(name, vtx);
+    }
+
+    /// Get class variable
+    pub fn get_class_var(&self, name: &str) -> Option<VertexId> {
+        self.class_vars.get(name).copied()
+    }
 }
 
 /// Scope manager
@@ -295,5 +305,79 @@ impl ScopeManager {
                 scope.set_instance_var(name, vtx);
             }
         }
+    }
+
+    /// Lookup class variable in enclosing class scope.
+    ///
+    /// Note: Only searches `ScopeKind::Class` scopes. Module-scoped @@var and
+    /// inheritance-chain traversal are not supported in v0.2.0.
+    pub fn lookup_class_var(&self, name: &str) -> Option<VertexId> {
+        self.walk_scopes()
+            .find(|scope| matches!(&scope.kind, ScopeKind::Class { .. }))
+            .and_then(|scope| scope.get_class_var(name))
+    }
+
+    /// Set class variable in enclosing class scope.
+    ///
+    /// No-op if there is no enclosing `ScopeKind::Class` scope (e.g., top-level or module scope).
+    /// Module-scoped @@var support is planned for a future version.
+    pub fn set_class_var_in_class(&mut self, name: String, vtx: VertexId) {
+        let class_scope_id = self.walk_scopes()
+            .find(|scope| matches!(&scope.kind, ScopeKind::Class { .. }))
+            .map(|scope| scope.id);
+        if let Some(scope_id) = class_scope_id {
+            self.scopes
+                .get_mut(&scope_id)
+                .expect("scope id from walk_scopes must exist")
+                .set_class_var(name, vtx);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_class_var_set_and_get() {
+        let mut scope = Scope::new(ScopeId(0), ScopeKind::TopLevel, None);
+        let vtx = VertexId(1);
+        scope.set_class_var("@@count".to_string(), vtx);
+        assert_eq!(scope.get_class_var("@@count"), Some(vtx));
+        assert_eq!(scope.get_class_var("@@missing"), None);
+    }
+
+    #[test]
+    fn test_lookup_class_var_from_method_scope() {
+        let mut manager = ScopeManager::new();
+
+        // Class scope
+        let class_id = manager.new_scope(ScopeKind::Class {
+            name: "Counter".to_string(),
+            superclass: None,
+        });
+        manager.enter_scope(class_id);
+
+        let vtx = VertexId(42);
+        manager.set_class_var_in_class("@@count".to_string(), vtx);
+
+        // Method scope (inside the class)
+        let method_id = manager.new_scope(ScopeKind::Method {
+            name: "increment".to_string(),
+            receiver_type: Some("Counter".to_string()),
+            return_vertex: None,
+        });
+        manager.enter_scope(method_id);
+
+        // Should find @@count through the class scope
+        assert_eq!(manager.lookup_class_var("@@count"), Some(vtx));
+    }
+
+    #[test]
+    fn test_set_class_var_noop_without_class_scope() {
+        let mut manager = ScopeManager::new();
+        // At top-level, no class scope exists
+        manager.set_class_var_in_class("@@var".to_string(), VertexId(1));
+        assert_eq!(manager.lookup_class_var("@@var"), None);
     }
 }

--- a/test/class_variable_test.rb
+++ b/test/class_variable_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ClassVariableTest < Minitest::Test
+  include CLITestHelper
+
+  # ============================================
+  # No Error
+  # ============================================
+
+  def test_class_variable_basic
+    source = <<~RUBY
+      class Counter
+        @@count = 0
+
+        def increment
+          @@count = 1
+        end
+
+        def value
+          @@count.to_s
+        end
+      end
+    RUBY
+    assert_no_check_errors(source)
+  end
+
+  def test_class_variable_in_method
+    source = <<~RUBY
+      class Logger
+        def setup
+          @@prefix = "LOG"
+        end
+
+        def log(msg)
+          @@prefix.upcase
+        end
+      end
+    RUBY
+    assert_no_check_errors(source)
+  end
+
+  # ============================================
+  # Error Detection
+  # ============================================
+
+  def test_class_variable_write_before_read
+    source = <<~RUBY
+      class Config
+        def initialize
+          @@default = "production"
+        end
+
+        def env
+          @@default.upcase
+        end
+      end
+    RUBY
+    assert_no_check_errors(source)
+  end
+
+  def test_class_variable_type_error
+    source = <<~RUBY
+      class Counter
+        def setup
+          @@count = 42
+        end
+
+        def display
+          @@count.upcase
+        end
+      end
+    RUBY
+    assert_check_error(source, method_name: 'upcase', receiver_type: 'Integer')
+  end
+
+  def test_class_variable_type_error_in_same_method
+    source = <<~RUBY
+      class Broken
+        def run
+          @@value = 100
+          @@value.length
+        end
+      end
+    RUBY
+    assert_check_error(source, method_name: 'length', receiver_type: 'Integer')
+  end
+end


### PR DESCRIPTION
## Motivation

Ruby class variables (`@@var`) were previously ignored by MethodRay's type inference engine. All `@@var` references returned `None` (unresolved type), causing false negatives where invalid method calls on class variables were never detected.

## Changes

- **scope.rs**: Add `set_class_var`/`get_class_var` accessors to `Scope`, and `lookup_class_var`/`set_class_var_in_class` to `ScopeManager` (walks scope chain to find enclosing `Class` scope)
- **variables.rs**: Add `install_class_var_write`/`install_class_var_read` following the existing ivar pattern (edge-merge on second write for union types)
- **dispatch.rs**: Add `ClassVarWrite` variant to `NeedsChildKind`, handlers in `dispatch_simple`/`dispatch_needs_child`/`process_needs_child`
- **Rust unit tests**: 7 tests (scope.rs: 3, variables.rs: 4)
- **Ruby integration tests**: 5 tests (basic, cross-method, initialize-then-read, type error, same-method type error)

## Checked

- `cargo test --lib` — 36 passed
- `cargo clippy --lib --all-features` — 0 warnings
- `bundle exec rake test` — 276 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)