### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-04-05
+
+### Added
+
+- Add pattern matching type inference ([#103](https://github.com/dak2/method-ray/pull/103))
+- Add Lambda/Proc type inference support ([#104](https://github.com/dak2/method-ray/pull/104))
+- Add compound assignment type inference ([#105](https://github.com/dak2/method-ray/pull/105))
+- Add `defined?` type inference support ([#106](https://github.com/dak2/method-ray/pull/106))
+- Add `yield` type inference support ([#107](https://github.com/dak2/method-ray/pull/107))
+- Add control flow keyword support (`break`, `next`, `retry`, `redo`) ([#108](https://github.com/dak2/method-ray/pull/108))
+- Add backtick string type inference ([#109](https://github.com/dak2/method-ray/pull/109))
+- Add predicate type propagation to pattern variables in `case...in` ([#110](https://github.com/dak2/method-ray/pull/110))
+- Add constant type inference support ([#102](https://github.com/dak2/method-ray/pull/102))
+- Add global variable (`$var`) type tracking ([#100](https://github.com/dak2/method-ray/pull/100))
+- Add class variable (`@@var`) type tracking ([#99](https://github.com/dak2/method-ray/pull/99))
+
+### Fixed
+
+- Fix uninitialized `@@var` reads silently skipping downstream type checking ([#101](https://github.com/dak2/method-ray/pull/101))
+- Fix release workflow not triggered after tag push ([#88](https://github.com/dak2/method-ray/pull/88))
+
 ## [0.1.10] - 2026-03-24
 
 ### Added
@@ -159,6 +180,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 - `methodray check` - Static type checking for Ruby files
 
+[0.2.0]: https://github.com/dak2/method-ray/releases/tag/v0.2.0
 [0.1.10]: https://github.com/dak2/method-ray/releases/tag/v0.1.10
 [0.1.9]: https://github.com/dak2/method-ray/releases/tag/v0.1.9
 [0.1.8]: https://github.com/dak2/method-ray/releases/tag/v0.1.8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    method-ray (0.1.10)
+    method-ray (0.2.0)
       rbs (~> 3.0)
 
 GEM
@@ -66,7 +66,7 @@ CHECKSUMS
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  method-ray (0.1.10)
+  method-ray (0.2.0)
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.1) sha256=06f6a725d2cd91e5e7f2b7c32ba143631e1f7c8ae2fb918fc4cebec187e6a688

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methodray-core"
-version = "0.1.10"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methodray"
-version = "0.1.10"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/lib/methodray/version.rb
+++ b/lib/methodray/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MethodRay
-  VERSION = '0.1.10'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
## Motivation

Release v0.2.0 with significant type inference coverage improvements since v0.1.10.

## Changes

- Bump version to 0.2.0 (version.rb, Cargo.toml x2, Gemfile.lock)
- Update CHANGELOG.md with all changes since v0.1.10

### New features in v0.2.0

- Pattern matching type inference (#103)
- Lambda/Proc type inference (#104)
- Compound assignment type inference (#105)
- `defined?` type inference (#106)
- `yield` type inference (#107)
- Control flow keywords (`break`, `next`, `retry`, `redo`) (#108)
- Backtick string type inference (#109)
- Predicate type propagation to pattern variables (#110)
- Constant type inference (#102)
- Global variable (`$var`) type tracking (#100)
- Class variable (`@@var`) type tracking (#99)

### Fixes

- Fix uninitialized `@@var` reads skipping downstream type checking (#101)
- Fix release workflow dispatch (#88)

## Checked

- [x] `cargo test --lib` passes
- [x] `cargo clippy` clean
- [x] Bumped versions
- [x] CHANGELOG.md updated