### PR TITLE
Deprecate 'watch' subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,6 @@ gem install methodray
 bundle exec methodray check app/models/user.rb
 ```
 
-### Watching for File Changes, Re-checking Methods
-
-```bash
-# Watch a file for changes and re-check on save
-bundle exec methodray watch app/models/user.rb
-```
-
 #### Example Usage
 
 `bundle exec methodray check app/models/user.rb`

--- a/core/src/cli/args.rs
+++ b/core/src/cli/args.rs
@@ -25,7 +25,7 @@ pub enum Commands {
         verbose: bool,
     },
 
-    /// Watch a Ruby file and re-check on changes
+    /// [DEPRECATED] Watch a Ruby file and re-check on changes
     Watch {
         /// Ruby file to watch
         #[arg(value_name = "FILE")]

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -32,6 +32,7 @@ fn main() -> Result<()> {
             }
         }
         Commands::Watch { file } => {
+            eprintln!("WARNING: 'watch' is deprecated and will be removed in a future version.");
             commands::watch_file(&file)?;
         }
         Commands::Version => {

--- a/ext/src/cli.rs
+++ b/ext/src/cli.rs
@@ -19,6 +19,7 @@ fn main() -> Result<()> {
             }
         }
         Commands::Watch { file } => {
+            eprintln!("WARNING: 'watch' is deprecated and will be removed in a future version.");
             commands::watch_file(&file)?;
         }
         Commands::Version => {


### PR DESCRIPTION
## Motivation
The `watch` subcommand will be removed in a future release. Surface a deprecation warning now so users can migrate before the breaking change.

## Changes
- Mark `Watch` as `[DEPRECATED]` in `--help` output (`core/src/cli/args.rs`)
- Print a runtime warning to stderr on invocation in both the `core` and `ext` (gem) binaries
- Remove the "Watching for File Changes" section from README

## Checked
- [x] `cargo build --bin methodray --features cli` passes
- [x] `cargo test --lib` passes 
- [x] Verified warning appears on stderr when running `methodray watch`
- [x] Verified `[DEPRECATED]` label is shown in `methodray --help`

Generated with [Claude Code](https://claude.com/claude-code)