### PR TITLE
Fix gem name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Method-Ray supports Ruby 3.4 or later.
 ## Installation
 
 ```bash
-gem install methodray
+gem install method-ray
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Motivation

The `gem install` example in README.md did not match the actual gem name, so following the documentation would fail to install the gem.

- `spec.name` in `methodray.gemspec` is `method-ray`
- README instructed `gem install methodray`

## Changes

- Fix the installation command in README.md from `gem install methodray` to `gem install method-ray`

## Checked
- [x] Code compiles and tests passes