### PR TITLE
Deprecate 'methodray-lsp' binary

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,6 +12,7 @@ name = "methodray"
 path = "src/main.rs"
 required-features = ["cli"]
 
+# [DEPRECATED] methodray-lsp will be removed in a future version.
 [[bin]]
 name = "methodray-lsp"
 path = "src/lsp/main.rs"

--- a/core/src/lsp/main.rs
+++ b/core/src/lsp/main.rs
@@ -1,8 +1,11 @@
 //! LSP server binary entry point
+//!
+//! [DEPRECATED] methodray-lsp will be removed in a future version.
 
 use methodray_core::lsp;
 
 #[tokio::main]
 async fn main() {
+    eprintln!("WARNING: 'methodray-lsp' is deprecated and will be removed in a future version.");
     lsp::run_server().await;
 }


### PR DESCRIPTION
## Motivation
LSP/editor completion is no longer in scope for this project. Surface a deprecation warning now so any current users of `methodray-lsp` can migrate before the binary is removed in a future release.

## Changes
- Print a runtime warning to stderr on startup (`core/src/lsp/main.rs`)
- Add `[DEPRECATED]` notice to the binary's module doc comment
- Mark the `[[bin]]` section in `core/Cargo.toml` with a `[DEPRECATED]` comment

## Checked
- [x] \`cargo check --features lsp\` passes
- [x] \`cargo build --features lsp --bin methodray-lsp\` passes
- [x] Verified the warning appears on stderr when launching \`methodray-lsp\`

Generated with [Claude Code](https://claude.com/claude-code)