### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-05-03
+
+### Deprecated
+
+- Deprecate `watch` subcommand ([#113](https://github.com/dak2/method-ray/pull/113))
+- Deprecate `methodray-lsp` binary ([#116](https://github.com/dak2/method-ray/pull/116))
+
+### Fixed
+
+- Fix gem name in README ([#115](https://github.com/dak2/method-ray/pull/115))
+
 ## [0.2.0] - 2026-04-05
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    method-ray (0.2.0)
+    method-ray (0.2.1)
       rbs (~> 3.0)
 
 GEM
@@ -66,7 +66,7 @@ CHECKSUMS
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  method-ray (0.2.0)
+  method-ray (0.2.1)
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.1) sha256=06f6a725d2cd91e5e7f2b7c32ba143631e1f7c8ae2fb918fc4cebec187e6a688

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methodray-core"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [lib]

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methodray"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [lib]

--- a/lib/methodray/version.rb
+++ b/lib/methodray/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MethodRay
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
## Motivation

Cut a v0.2.1 patch release to ship deprecation notices and a README fix that have landed since v0.2.0.

## Changes

- Bump version to 0.2.1 (`core/Cargo.toml`, `ext/Cargo.toml`, `lib/methodray/version.rb`, `Gemfile.lock`)
- Update `CHANGELOG.md`:
  - **Deprecated**: `watch` subcommand (#113), `methodray-lsp` binary (#116)
  - **Fixed**: gem name in README (#115)

## Checked

- [x] `cargo build --lib` passes with new version
- [ ] Auto-tag workflow creates `v0.2.1` tag on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)